### PR TITLE
feat(catalog): expandir catálogo de 52 para 450 itens com batch loading

### DIFF
--- a/features/catalog-expansion/REPORT.md
+++ b/features/catalog-expansion/REPORT.md
@@ -1,0 +1,75 @@
+# REPORT — feat/catalog-expansion
+
+**Status:** READY_FOR_COMMIT
+**Data:** 2026-03-16
+**Branch:** feat/catalog-expansion
+
+---
+
+## O que mudou
+
+### `src/data/constants.ts`
+- Introduzido `ITEM_CATALOG` com 17 categorias (swords, axes, spears, daggers, bows, fire_staves, frost_staves, holy_staves, arcane_staves, cursed_staves, plate, leather, cloth, off_hands, bags, capes, resources)
+- `ITEM_IDS` agora derivado de `ITEM_CATALOG` — 450 IDs únicos (era ~52 hardcoded)
+- `ITEM_NAMES` gerado programaticamente via `TYPE_LABELS` para todos os 450 IDs
+- Helper interno `genIds(types)` elimina repetição de tier × tipo
+
+### `src/services/market.api.ts`
+- Exportadas funções utilitárias `chunkArray<T>` e `withConcurrency<T>`
+- `BATCH_SIZE = 100` e `HISTORY_CONCURRENCY = 3` exportados como constantes
+- `getItems()` refatorado para processar batches com concorrência controlada
+- AbortController único compartilhado entre todos os price batches (timeout 15s)
+- Deduplicação por `${item_id}|${city}|${quality}` antes de processar itens
+- Fallback para `MockMarketService` quando nenhum registro de preço retorna
+
+### `src/components/dashboard/PriceTable.tsx`
+- Adicionado `<Select aria-label="Category">` com opções derivadas de `ITEM_CATALOG`
+- Filtro de categoria client-side, sem re-fetch
+- Estado `categoryFilter` integrado ao `useMemo` de filtragem existente
+
+### Novos arquivos de teste
+- `src/test/catalog.test.ts` — AC1 (≥400 IDs únicos) e AC2 (sem duplicatas)
+- `src/test/market.api.batch.test.ts` — AC3 (≥2 price fetches com 200 IDs), AC4 (falha em 1 batch não cancela outros), AC5 (concorrência ≤ HISTORY_CONCURRENCY), AC7 (chunkArray)
+- `src/test/PriceTable.test.tsx` — AC6 (Select de categoria com aria-label)
+
+---
+
+## Por que mudou
+
+O dashboard rastreava ~52 itens hardcoded enquanto o jogo tem 3000+ itens. A expansão para 450 IDs estratégicos (T4–T8 em todas as categorias principais) multiplica o valor de arbitragem cross-city por ~10× sem violar os rate limits da API (180 req/min — custo por refresh com 5 batches: ~40 requests).
+
+---
+
+## Como foi validado
+
+| Critério | Verificação | Resultado |
+|----------|------------|-----------|
+| AC1: ≥400 IDs únicos | `catalog.test.ts` | ✅ 450 IDs |
+| AC2: Sem duplicatas | `catalog.test.ts` | ✅ |
+| AC3: ≥2 price fetches com 200 IDs | `market.api.batch.test.ts` | ✅ |
+| AC4: Falha em 1 batch não cancela outros | `market.api.batch.test.ts` | ✅ |
+| AC5: Concorrência ≤ HISTORY_CONCURRENCY | `market.api.batch.test.ts` | ✅ |
+| AC6: Select de categoria no PriceTable | `PriceTable.test.tsx` | ✅ |
+| AC7: 65 testes existentes passando | `npm run test` | ✅ 65/65 |
+| Lint | `npm run lint` | ✅ 0 erros |
+| Build | `npm run build` | ✅ sem erros |
+
+---
+
+## security-review
+
+**Status:** SKIPPED — justificativa: feature exclusivamente de produto (constantes de domínio, lógica de serviço de mercado e componente de UI). Não toca CI/CD, autenticação, secrets, infraestrutura, permissões nem APIs públicas. Nenhum dos triggers obrigatórios de security-review se aplica.
+
+---
+
+## Riscos residuais
+
+- Bundle de `constants.ts` cresce ~30–50 KB (450 IDs + TYPE_LABELS). Aceitável — dados estáticos, compressão gzip reduz para ~5–8 KB em produção.
+- Rate limit da API: 5 batches × 1 price request = 5 requests por refresh. Com staleTime de 15 min, bem dentro dos 180 req/min.
+
+---
+
+## Próximos passos
+
+- Monitorar comportamento com a API real (`VITE_USE_REAL_API=true`)
+- Avaliar adição de enchanted items (`.@1`, `.@2`, `.@3`) em feature futura

--- a/src/components/dashboard/PriceTable.tsx
+++ b/src/components/dashboard/PriceTable.tsx
@@ -9,7 +9,8 @@ import {
   ChevronRight
 } from 'lucide-react';
 import type { MarketItem } from '@/data/types';
-import { cities, tiers, qualities } from '@/data/constants';
+import { cities, tiers, qualities, ITEM_CATALOG } from '@/data/constants';
+import type { CatalogCategoryKey } from '@/data/constants';
 import { Sparkline } from '@/components/ui/sparkline';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -32,6 +33,7 @@ type SortDirection = 'asc' | 'desc';
 
 export function PriceTable({ items, className }: PriceTableProps) {
   const [search, setSearch] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState<CatalogCategoryKey | 'all'>('all');
   const [cityFilter, setCityFilter] = useState<string>('all');
   const [tierFilter, setTierFilter] = useState<string>('all');
   const [qualityFilter, setQualityFilter] = useState<string>('all');
@@ -44,6 +46,11 @@ export function PriceTable({ items, className }: PriceTableProps) {
     let result = [...items];
 
     // Apply filters
+    if (categoryFilter !== 'all') {
+      const ids = new Set(ITEM_CATALOG[categoryFilter].ids);
+      result = result.filter(item => ids.has(item.itemId));
+    }
+
     if (search) {
       const searchLower = search.toLowerCase();
       result = result.filter(
@@ -84,7 +91,7 @@ export function PriceTable({ items, className }: PriceTableProps) {
     });
 
     return result;
-  }, [items, search, cityFilter, tierFilter, qualityFilter, sortField, sortDirection]);
+  }, [items, search, categoryFilter, cityFilter, tierFilter, qualityFilter, sortField, sortDirection]);
 
   const totalPages = Math.ceil(filteredAndSortedItems.length / itemsPerPage);
   const paginatedItems = filteredAndSortedItems.slice(
@@ -138,6 +145,18 @@ export function PriceTable({ items, className }: PriceTableProps) {
           </div>
           
           <div className="flex flex-wrap gap-2">
+            <Select value={categoryFilter} onValueChange={(v) => setCategoryFilter(v as CatalogCategoryKey | 'all')}>
+              <SelectTrigger className="w-[150px] bg-muted/50 border-border/50" aria-label="Category">
+                <SelectValue placeholder="Category" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Categories</SelectItem>
+                {(Object.entries(ITEM_CATALOG) as [CatalogCategoryKey, { label: string }][]).map(([key, cat]) => (
+                  <SelectItem key={key} value={key}>{cat.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
             <Select value={cityFilter} onValueChange={setCityFilter}>
               <SelectTrigger className="w-[140px] bg-muted/50 border-border/50">
                 <Filter className="h-3 w-3 mr-2" />

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -12,81 +12,246 @@ export const tiers = ['T4', 'T5', 'T6', 'T7', 'T8'] as const;
 
 export const qualities = ['Normal', 'Good', 'Outstanding', 'Excellent', 'Masterpiece'] as const;
 
-export const ITEM_IDS: string[] = [
-  // Swords (T4–T8)
-  'T4_MAIN_SWORD', 'T4_2H_SWORD',
-  'T5_MAIN_SWORD', 'T5_2H_SWORD',
-  'T6_MAIN_SWORD', 'T6_2H_SWORD',
-  'T7_MAIN_SWORD', 'T7_2H_SWORD',
-  'T8_MAIN_SWORD', 'T8_2H_SWORD',
-  // Axes (T4–T7)
-  'T4_MAIN_AXE', 'T4_2H_AXE',
-  'T5_MAIN_AXE', 'T5_2H_AXE',
-  'T6_MAIN_AXE', 'T6_2H_AXE',
-  'T7_MAIN_AXE', 'T7_2H_AXE',
-  // Spears (T4–T7)
-  'T4_MAIN_SPEAR', 'T5_MAIN_SPEAR', 'T6_MAIN_SPEAR', 'T7_MAIN_SPEAR',
-  // Daggers (T4–T6)
-  'T4_MAIN_DAGGER', 'T5_MAIN_DAGGER', 'T6_MAIN_DAGGER',
-  // Bows (T4–T7)
-  'T4_MAIN_BOW', 'T5_MAIN_BOW', 'T6_MAIN_BOW', 'T7_MAIN_BOW',
-  // Fire Staves (T4–T6)
-  'T4_MAIN_FIRESTAFF', 'T5_MAIN_FIRESTAFF', 'T6_MAIN_FIRESTAFF',
-  // Holy Staves (T4–T5)
-  'T4_MAIN_HOLYSTAFF', 'T5_MAIN_HOLYSTAFF',
-  // Plate armor (T4–T6)
-  'T4_ARMOR_PLATE_SET1', 'T4_HEAD_PLATE_SET1', 'T4_SHOES_PLATE_SET1',
-  'T5_ARMOR_PLATE_SET1', 'T5_HEAD_PLATE_SET1', 'T5_SHOES_PLATE_SET1',
-  'T6_ARMOR_PLATE_SET1', 'T6_HEAD_PLATE_SET1', 'T6_SHOES_PLATE_SET1',
-  // Leather armor (T4–T6)
-  'T4_ARMOR_LEATHER_SET1', 'T4_HEAD_LEATHER_SET1', 'T4_SHOES_LEATHER_SET1',
-  'T5_ARMOR_LEATHER_SET1', 'T5_HEAD_LEATHER_SET1', 'T5_SHOES_LEATHER_SET1',
-  'T6_ARMOR_LEATHER_SET1', 'T6_HEAD_LEATHER_SET1', 'T6_SHOES_LEATHER_SET1',
-  // Cloth armor (T4–T5)
-  'T4_ARMOR_CLOTH_SET1', 'T4_HEAD_CLOTH_SET1', 'T4_SHOES_CLOTH_SET1',
-  'T5_ARMOR_CLOTH_SET1', 'T5_HEAD_CLOTH_SET1', 'T5_SHOES_CLOTH_SET1',
-  // Bags (T4–T8)
-  'T4_BAG', 'T5_BAG', 'T6_BAG', 'T7_BAG', 'T8_BAG',
-  // Capes (T4–T6)
-  'T4_CAPE', 'T5_CAPE', 'T6_CAPE',
-];
+export interface CatalogCategory {
+  label: string;
+  ids: string[];
+}
 
-export const ITEM_NAMES: Record<string, string> = {
-  // Swords
-  'T4_MAIN_SWORD': 'Broadsword T4', 'T4_2H_SWORD': 'Claymore T4',
-  'T5_MAIN_SWORD': 'Broadsword T5', 'T5_2H_SWORD': 'Claymore T5',
-  'T6_MAIN_SWORD': 'Broadsword T6', 'T6_2H_SWORD': 'Claymore T6',
-  'T7_MAIN_SWORD': 'Broadsword T7', 'T7_2H_SWORD': 'Claymore T7',
-  'T8_MAIN_SWORD': 'Broadsword T8', 'T8_2H_SWORD': 'Claymore T8',
-  // Axes
-  'T4_MAIN_AXE': 'Battleaxe T4', 'T4_2H_AXE': 'Greataxe T4',
-  'T5_MAIN_AXE': 'Battleaxe T5', 'T5_2H_AXE': 'Greataxe T5',
-  'T6_MAIN_AXE': 'Battleaxe T6', 'T6_2H_AXE': 'Greataxe T6',
-  'T7_MAIN_AXE': 'Battleaxe T7', 'T7_2H_AXE': 'Greataxe T7',
-  // Spears
-  'T4_MAIN_SPEAR': 'Spear T4', 'T5_MAIN_SPEAR': 'Spear T5',
-  'T6_MAIN_SPEAR': 'Spear T6', 'T7_MAIN_SPEAR': 'Spear T7',
-  // Daggers
-  'T4_MAIN_DAGGER': 'Dagger T4', 'T5_MAIN_DAGGER': 'Dagger T5', 'T6_MAIN_DAGGER': 'Dagger T6',
-  // Bows
-  'T4_MAIN_BOW': 'Bow T4', 'T5_MAIN_BOW': 'Bow T5',
-  'T6_MAIN_BOW': 'Bow T6', 'T7_MAIN_BOW': 'Bow T7',
-  // Staves
-  'T4_MAIN_FIRESTAFF': 'Fire Staff T4', 'T5_MAIN_FIRESTAFF': 'Fire Staff T5', 'T6_MAIN_FIRESTAFF': 'Fire Staff T6',
-  'T4_MAIN_HOLYSTAFF': 'Holy Staff T4', 'T5_MAIN_HOLYSTAFF': 'Holy Staff T5',
-  // Plate armor
-  'T4_ARMOR_PLATE_SET1': 'Plate Armor T4', 'T4_HEAD_PLATE_SET1': 'Plate Helm T4', 'T4_SHOES_PLATE_SET1': 'Plate Boots T4',
-  'T5_ARMOR_PLATE_SET1': 'Plate Armor T5', 'T5_HEAD_PLATE_SET1': 'Plate Helm T5', 'T5_SHOES_PLATE_SET1': 'Plate Boots T5',
-  'T6_ARMOR_PLATE_SET1': 'Plate Armor T6', 'T6_HEAD_PLATE_SET1': 'Plate Helm T6', 'T6_SHOES_PLATE_SET1': 'Plate Boots T6',
-  // Leather armor
-  'T4_ARMOR_LEATHER_SET1': 'Leather Armor T4', 'T4_HEAD_LEATHER_SET1': 'Leather Hood T4', 'T4_SHOES_LEATHER_SET1': 'Leather Shoes T4',
-  'T5_ARMOR_LEATHER_SET1': 'Leather Armor T5', 'T5_HEAD_LEATHER_SET1': 'Leather Hood T5', 'T5_SHOES_LEATHER_SET1': 'Leather Shoes T5',
-  'T6_ARMOR_LEATHER_SET1': 'Leather Armor T6', 'T6_HEAD_LEATHER_SET1': 'Leather Hood T6', 'T6_SHOES_LEATHER_SET1': 'Leather Shoes T6',
-  // Cloth armor
-  'T4_ARMOR_CLOTH_SET1': 'Cloth Robe T4', 'T4_HEAD_CLOTH_SET1': 'Cloth Cowl T4', 'T4_SHOES_CLOTH_SET1': 'Cloth Sandals T4',
-  'T5_ARMOR_CLOTH_SET1': 'Cloth Robe T5', 'T5_HEAD_CLOTH_SET1': 'Cloth Cowl T5', 'T5_SHOES_CLOTH_SET1': 'Cloth Sandals T5',
-  // Bags
-  'T4_BAG': 'Bag T4', 'T5_BAG': 'Bag T5', 'T6_BAG': 'Bag T6', 'T7_BAG': 'Bag T7', 'T8_BAG': 'Bag T8',
-  // Capes
-  'T4_CAPE': 'Cape T4', 'T5_CAPE': 'Cape T5', 'T6_CAPE': 'Cape T6',
+export type CatalogCategoryKey =
+  | 'swords'
+  | 'axes'
+  | 'spears'
+  | 'daggers'
+  | 'bows'
+  | 'fire_staves'
+  | 'frost_staves'
+  | 'holy_staves'
+  | 'arcane_staves'
+  | 'cursed_staves'
+  | 'plate'
+  | 'leather'
+  | 'cloth'
+  | 'off_hands'
+  | 'bags'
+  | 'capes'
+  | 'resources';
+
+function genIds(types: string[]): string[] {
+  return ['T4', 'T5', 'T6', 'T7', 'T8'].flatMap(tier =>
+    types.map(type => `${tier}_${type}`)
+  );
+}
+
+export const ITEM_CATALOG: Record<CatalogCategoryKey, CatalogCategory> = {
+  swords: {
+    label: 'Swords',
+    ids: genIds([
+      'MAIN_SWORD', '2H_SWORD', '2H_CLAYMORE', 'MAIN_LONGSWORD', '2H_DUAL_SWORD',
+    ]),
+  },
+  axes: {
+    label: 'Axes',
+    ids: genIds([
+      'MAIN_AXE', '2H_AXE', '2H_HALBERD', '2H_BATTLEAXE', 'MAIN_DUALAXE',
+    ]),
+  },
+  spears: {
+    label: 'Spears',
+    ids: genIds([
+      'MAIN_SPEAR', '2H_SPEAR', '2H_PIKE', '2H_LANCE', '2H_GLAIVE',
+    ]),
+  },
+  daggers: {
+    label: 'Daggers',
+    ids: genIds([
+      'MAIN_DAGGER', '2H_DAGGER', '2H_CLAWS', 'MAIN_DAGGERPAIR', 'MAIN_BLOODLETTER',
+    ]),
+  },
+  bows: {
+    label: 'Bows',
+    ids: genIds([
+      'MAIN_BOW', '2H_BOW', '2H_WARBOW', 'MAIN_CROSSBOW', '2H_LONGBOW',
+    ]),
+  },
+  fire_staves: {
+    label: 'Fire Staves',
+    ids: genIds([
+      'MAIN_FIRESTAFF', '2H_FIRESTAFF', '2H_INFERNOSTAFF', '2H_BLAZINGSTAFF', '2H_DRUIDSTAFF',
+    ]),
+  },
+  frost_staves: {
+    label: 'Frost Staves',
+    ids: genIds([
+      'MAIN_FROSTSTAFF', '2H_FROSTSTAFF', '2H_ICICLESTAFF', '2H_GLACIALSTAFF', '2H_PERMAFROST',
+    ]),
+  },
+  holy_staves: {
+    label: 'Holy Staves',
+    ids: genIds([
+      'MAIN_HOLYSTAFF', '2H_HOLYSTAFF', '2H_DIVINESTAFF', '2H_LIFETOUCH', '2H_HOLYBOOK',
+    ]),
+  },
+  arcane_staves: {
+    label: 'Arcane Staves',
+    ids: genIds([
+      'MAIN_ARCANESTAFF', '2H_ARCANESTAFF', '2H_ENIGMATICSTAFF', '2H_OCCULTSTAFF', '2H_SOULSCYTHE',
+    ]),
+  },
+  cursed_staves: {
+    label: 'Cursed Staves',
+    ids: genIds([
+      'MAIN_CURSEDSTAFF', '2H_CURSEDSTAFF', '2H_DEMONICSTAFF', '2H_SKULLS', '2H_GRAVECALLER',
+    ]),
+  },
+  plate: {
+    label: 'Plate Armor',
+    ids: genIds([
+      'ARMOR_PLATE_SET1', 'HEAD_PLATE_SET1', 'SHOES_PLATE_SET1',
+      'ARMOR_PLATE_SET2', 'HEAD_PLATE_SET2', 'SHOES_PLATE_SET2',
+      'ARMOR_PLATE_SET3', 'HEAD_PLATE_SET3', 'SHOES_PLATE_SET3',
+    ]),
+  },
+  leather: {
+    label: 'Leather Armor',
+    ids: genIds([
+      'ARMOR_LEATHER_SET1', 'HEAD_LEATHER_SET1', 'SHOES_LEATHER_SET1',
+      'ARMOR_LEATHER_SET2', 'HEAD_LEATHER_SET2', 'SHOES_LEATHER_SET2',
+      'ARMOR_LEATHER_SET3', 'HEAD_LEATHER_SET3', 'SHOES_LEATHER_SET3',
+    ]),
+  },
+  cloth: {
+    label: 'Cloth Armor',
+    ids: genIds([
+      'ARMOR_CLOTH_SET1', 'HEAD_CLOTH_SET1', 'SHOES_CLOTH_SET1',
+      'ARMOR_CLOTH_SET2', 'HEAD_CLOTH_SET2', 'SHOES_CLOTH_SET2',
+      'ARMOR_CLOTH_SET3', 'HEAD_CLOTH_SET3', 'SHOES_CLOTH_SET3',
+    ]),
+  },
+  off_hands: {
+    label: 'Off-hands',
+    ids: genIds([
+      'OFFHAND_SHIELD', 'OFFHAND_TORCH', 'OFFHAND_BOOK',
+      'OFFHAND_TOTEM', 'OFFHAND_ORB', 'OFFHAND_HORN',
+    ]),
+  },
+  bags: {
+    label: 'Bags',
+    ids: ['T4_BAG', 'T5_BAG', 'T6_BAG', 'T7_BAG', 'T8_BAG'],
+  },
+  capes: {
+    label: 'Capes',
+    ids: ['T4_CAPE', 'T5_CAPE', 'T6_CAPE', 'T7_CAPE', 'T8_CAPE'],
+  },
+  resources: {
+    label: 'Resources',
+    ids: genIds(['HIDE', 'ORE', 'FIBER', 'WOOD', 'ROCK']),
+  },
 };
+
+export const ITEM_IDS: string[] = Object.values(ITEM_CATALOG).flatMap(c => c.ids);
+
+const TYPE_LABELS: Record<string, string> = {
+  'MAIN_SWORD': 'Broadsword',
+  '2H_SWORD': 'Claymore',
+  '2H_CLAYMORE': 'Great Claymore',
+  'MAIN_LONGSWORD': 'Carving Sword',
+  '2H_DUAL_SWORD': 'Dual Swords',
+  'MAIN_AXE': 'Battleaxe',
+  '2H_AXE': 'Greataxe',
+  '2H_HALBERD': 'Halberd',
+  '2H_BATTLEAXE': 'War Axe',
+  'MAIN_DUALAXE': 'Dual Axes',
+  'MAIN_SPEAR': 'Spear',
+  '2H_SPEAR': 'Pike',
+  '2H_PIKE': 'Heavy Pike',
+  '2H_LANCE': 'Lance',
+  '2H_GLAIVE': 'War Glaive',
+  'MAIN_DAGGER': 'Dagger',
+  '2H_DAGGER': 'Demonic Blades',
+  '2H_CLAWS': 'Claws',
+  'MAIN_DAGGERPAIR': 'Bridled Fury',
+  'MAIN_BLOODLETTER': 'Bloodletter',
+  'MAIN_BOW': 'Bow',
+  '2H_BOW': 'Warbow',
+  '2H_WARBOW': 'Longbow',
+  'MAIN_CROSSBOW': 'Crossbow',
+  '2H_LONGBOW': 'Carrioncaller',
+  'MAIN_FIRESTAFF': 'Fire Staff',
+  '2H_FIRESTAFF': 'Great Fire Staff',
+  '2H_INFERNOSTAFF': 'Infernal Staff',
+  '2H_BLAZINGSTAFF': 'Blazing Staff',
+  '2H_DRUIDSTAFF': 'Druidic Staff',
+  'MAIN_FROSTSTAFF': 'Frost Staff',
+  '2H_FROSTSTAFF': 'Great Frost Staff',
+  '2H_ICICLESTAFF': 'Icicle Staff',
+  '2H_GLACIALSTAFF': 'Glacial Staff',
+  '2H_PERMAFROST': 'Permafrost Prism',
+  'MAIN_HOLYSTAFF': 'Holy Staff',
+  '2H_HOLYSTAFF': 'Great Holy Staff',
+  '2H_DIVINESTAFF': 'Divine Staff',
+  '2H_LIFETOUCH': 'Life Touch Staff',
+  '2H_HOLYBOOK': 'Fallen Staff',
+  'MAIN_ARCANESTAFF': 'Arcane Staff',
+  '2H_ARCANESTAFF': 'Great Arcane Staff',
+  '2H_ENIGMATICSTAFF': 'Enigmatic Staff',
+  '2H_OCCULTSTAFF': 'Occult Staff',
+  '2H_SOULSCYTHE': 'Soulscythe',
+  'MAIN_CURSEDSTAFF': 'Cursed Staff',
+  '2H_CURSEDSTAFF': 'Great Cursed Staff',
+  '2H_DEMONICSTAFF': 'Demonic Staff',
+  '2H_SKULLS': 'Cursed Skull',
+  '2H_GRAVECALLER': 'Gravecaller',
+  'ARMOR_PLATE_SET1': 'Soldier Armor',
+  'HEAD_PLATE_SET1': 'Soldier Helmet',
+  'SHOES_PLATE_SET1': 'Soldier Boots',
+  'ARMOR_PLATE_SET2': 'Knight Armor',
+  'HEAD_PLATE_SET2': 'Knight Helmet',
+  'SHOES_PLATE_SET2': 'Knight Boots',
+  'ARMOR_PLATE_SET3': 'Guardian Armor',
+  'HEAD_PLATE_SET3': 'Guardian Helmet',
+  'SHOES_PLATE_SET3': 'Guardian Boots',
+  'ARMOR_LEATHER_SET1': 'Leather Armor',
+  'HEAD_LEATHER_SET1': 'Leather Hood',
+  'SHOES_LEATHER_SET1': 'Leather Shoes',
+  'ARMOR_LEATHER_SET2': 'Assassin Jacket',
+  'HEAD_LEATHER_SET2': 'Assassin Hood',
+  'SHOES_LEATHER_SET2': 'Assassin Shoes',
+  'ARMOR_LEATHER_SET3': 'Royal Jacket',
+  'HEAD_LEATHER_SET3': 'Royal Hood',
+  'SHOES_LEATHER_SET3': 'Royal Shoes',
+  'ARMOR_CLOTH_SET1': 'Cloth Robe',
+  'HEAD_CLOTH_SET1': 'Cloth Cowl',
+  'SHOES_CLOTH_SET1': 'Cloth Sandals',
+  'ARMOR_CLOTH_SET2': 'Scholar Robe',
+  'HEAD_CLOTH_SET2': 'Scholar Cowl',
+  'SHOES_CLOTH_SET2': 'Scholar Sandals',
+  'ARMOR_CLOTH_SET3': 'Mage Robe',
+  'HEAD_CLOTH_SET3': 'Mage Cowl',
+  'SHOES_CLOTH_SET3': 'Mage Sandals',
+  'OFFHAND_SHIELD': 'Shield',
+  'OFFHAND_TORCH': 'Torch',
+  'OFFHAND_BOOK': 'Focus Tome',
+  'OFFHAND_TOTEM': 'Totem',
+  'OFFHAND_ORB': 'Arcane Orb',
+  'OFFHAND_HORN': 'Horn',
+  'BAG': 'Bag',
+  'CAPE': 'Cape',
+  'HIDE': 'Hide',
+  'ORE': 'Ore',
+  'FIBER': 'Fiber',
+  'WOOD': 'Wood',
+  'ROCK': 'Rock',
+};
+
+export const ITEM_NAMES: Record<string, string> = Object.fromEntries(
+  ITEM_IDS.map(id => {
+    const tier = id.match(/^(T\d)/)?.[1] ?? '';
+    const type = id.replace(/^T\d_/, '');
+    const label = TYPE_LABELS[type];
+    if (label) return [id, `${label} ${tier}`];
+    const fallback = type
+      .replace(/_/g, ' ')
+      .replace(/\b(\w)/g, (_, c: string) => c.toUpperCase());
+    return [id, `${fallback} ${tier}`];
+  })
+);

--- a/src/services/market.api.ts
+++ b/src/services/market.api.ts
@@ -1,12 +1,16 @@
 import type { MarketItem, Alert } from '@/data/types';
 import type { MarketService } from './market.service';
 import { AlbionPriceRecordSchema, AlbionHistoryRecordSchema, albionRecordToMarketItem } from './market.api.types';
+import type { AlbionPriceRecord } from './market.api.types';
 import { AlertStorageService } from './alert.storage';
 import { ITEM_IDS, ITEM_NAMES } from '@/data/constants';
 import { MockMarketService } from './market.mock';
 
 const BASE_URL = 'https://west.albion-online-data.com/api/v2/stats/prices';
 const HISTORY_URL = 'https://west.albion-online-data.com/api/v2/stats/history';
+
+export const BATCH_SIZE = 100;
+export const HISTORY_CONCURRENCY = 3;
 
 const LOCATIONS = [
   'Caerleon',
@@ -23,40 +27,88 @@ type Location = typeof LOCATIONS[number];
 // Key: `${itemId}|${city}`, value: array of avg_prices ordered oldest→newest
 type HistoryMap = Map<string, number[]>;
 
+export function chunkArray<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}
+
+export async function withConcurrency<T>(
+  tasks: (() => Promise<T>)[],
+  limit: number
+): Promise<T[]> {
+  const results: T[] = new Array(tasks.length);
+  let index = 0;
+
+  async function worker(): Promise<void> {
+    while (index < tasks.length) {
+      const i = index++;
+      results[i] = await tasks[i]();
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(limit, tasks.length) },
+    () => worker()
+  );
+  await Promise.all(workers);
+  return results;
+}
+
 export class ApiMarketService implements MarketService {
   private storage = new AlertStorageService();
   private fallback = new MockMarketService();
   private cachedLastUpdate: string = new Date().toISOString();
 
-  private async fetchHistoryForCity(city: Location): Promise<HistoryMap> {
+  private async fetchPricesBatch(itemIds: string[], signal?: AbortSignal): Promise<AlbionPriceRecord[]> {
+    const locationsParam = LOCATIONS.join(',');
+    const url = `${BASE_URL}/${itemIds.join(',')}.json?locations=${locationsParam}&qualities=1,2,3,4,5`;
+    const response = await fetch(url, { signal });
+    if (!response.ok) throw new Error(`Albion API error: ${response.status}`);
+    const raw: unknown[] = await response.json();
+    return raw
+      .map(r => {
+        const result = AlbionPriceRecordSchema.safeParse(r);
+        return result.success ? result.data : null;
+      })
+      .filter((r): r is AlbionPriceRecord => r !== null);
+  }
+
+  private async fetchHistoryBatch(itemIds: string[], city: Location): Promise<HistoryMap> {
     const map: HistoryMap = new Map();
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 15_000);
-
     try {
-      const url = `${HISTORY_URL}/${ITEM_IDS.join(',')}.json?locations=${city}&qualities=1&time-scale=1`;
-      const response = await fetch(url, { signal: controller.signal });
-      clearTimeout(timeoutId);
-
+      const url = `${HISTORY_URL}/${itemIds.join(',')}.json?locations=${city}&qualities=1&time-scale=1`;
+      const response = await fetch(url);
       if (!response.ok) throw new Error(`History API error: ${response.status}`);
-
       const raw: unknown[] = await response.json();
-
       for (const record of raw) {
         const result = AlbionHistoryRecordSchema.safeParse(record);
         if (!result.success || result.data.data.length === 0) continue;
-
         const sorted = [...result.data.data]
           .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
           .map(d => d.avg_price);
-
         map.set(`${result.data.item_id}|${result.data.location}`, sorted);
       }
     } catch {
-      clearTimeout(timeoutId);
+      // silent — history enrichment is best-effort
     }
-
     return map;
+  }
+
+  private async buildHistoryMap(batches: string[][]): Promise<HistoryMap> {
+    const merged: HistoryMap = new Map();
+    const tasks = batches.flatMap(batch =>
+      LOCATIONS.map(city => async () => this.fetchHistoryBatch(batch, city))
+    );
+    const batchMaps = await withConcurrency(tasks, HISTORY_CONCURRENCY);
+    for (const batchMap of batchMaps) {
+      for (const [key, prices] of batchMap) {
+        merged.set(key, prices);
+      }
+    }
+    return merged;
   }
 
   async getItems(): Promise<MarketItem[]> {
@@ -64,41 +116,47 @@ export class ApiMarketService implements MarketService {
     const timeoutId = setTimeout(() => controller.abort(), 15_000);
 
     try {
-      const locationsParam = LOCATIONS.join(',');
-      const url = `${BASE_URL}/${ITEM_IDS.join(',')}.json?locations=${locationsParam}&qualities=1,2,3,4,5`;
-      const response = await fetch(url, { signal: controller.signal });
+      const batches = chunkArray(ITEM_IDS, BATCH_SIZE);
+
+      const priceTasks = batches.map(batch => async () => {
+        if (controller.signal.aborted) return [] as AlbionPriceRecord[];
+        try {
+          return await this.fetchPricesBatch(batch, controller.signal);
+        } catch {
+          return [] as AlbionPriceRecord[];
+        }
+      });
+
+      const batchResults = await withConcurrency(priceTasks, 3);
       clearTimeout(timeoutId);
 
-      if (!response.ok) {
-        throw new Error(`Albion API error: ${response.status}`);
+      // Deduplicate across batches (first occurrence wins)
+      const seen = new Set<string>();
+      const allPriceRecords = batchResults.flat().filter(r => {
+        const key = `${r.item_id}|${r.city}|${r.quality}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+
+      if (allPriceRecords.length === 0) {
+        return this.fallback.getItems();
       }
 
-      const raw: unknown[] = await response.json();
       this.cachedLastUpdate = new Date().toISOString();
 
-      const items = raw
-        .map(record => {
-          const result = AlbionPriceRecordSchema.safeParse(record);
-          return result.success ? albionRecordToMarketItem(result.data) : null;
-        })
-        .filter((item): item is MarketItem => item !== null)
+      const items = allPriceRecords
+        .map(record => albionRecordToMarketItem(record))
         .filter(item => item.sellPrice > 0 && item.buyPrice > 0)
         .map(item => ({
           ...item,
           itemName: ITEM_NAMES[item.itemId] ?? item.itemName,
         }));
 
-      // Enrich with price history (parallel requests per city, failures are silent)
-      const historyMaps = await Promise.all(
-        LOCATIONS.map(city => this.fetchHistoryForCity(city))
-      );
-      const merged: HistoryMap = new Map();
-      for (const map of historyMaps) {
-        for (const [key, prices] of map) merged.set(key, prices);
-      }
+      const historyMap = await this.buildHistoryMap(batches);
 
       return items.map(item => {
-        const history = merged.get(`${item.itemId}|${item.city}`);
+        const history = historyMap.get(`${item.itemId}|${item.city}`);
         return history ? { ...item, priceHistory: history } : item;
       });
     } catch {

--- a/src/test/PriceTable.test.tsx
+++ b/src/test/PriceTable.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PriceTable } from '@/components/dashboard/PriceTable';
+import type { MarketItem } from '@/data/types';
+
+const mockItems: MarketItem[] = [
+  {
+    itemId: 'T4_MAIN_SWORD',
+    itemName: 'Broadsword T4',
+    city: 'Caerleon',
+    sellPrice: 50000,
+    buyPrice: 40000,
+    spread: 10000,
+    spreadPercent: 25,
+    timestamp: new Date().toISOString(),
+    tier: 'T4',
+    quality: 'Normal',
+    priceHistory: [45000, 46000, 47000],
+  },
+  {
+    itemId: 'T5_MAIN_AXE',
+    itemName: 'Battleaxe T5',
+    city: 'Bridgewatch',
+    sellPrice: 80000,
+    buyPrice: 60000,
+    spread: 20000,
+    spreadPercent: 33,
+    timestamp: new Date().toISOString(),
+    tier: 'T5',
+    quality: 'Normal',
+    priceHistory: [75000, 77000, 80000],
+  },
+];
+
+describe('PriceTable — filtro de categoria (AC6)', () => {
+  it('exibe Select de categoria com opção "All Categories"', () => {
+    render(<PriceTable items={mockItems} />);
+
+    expect(screen.getByRole('combobox', { name: /category/i })).toBeInTheDocument();
+  });
+
+  it('exibe labels de categoria legíveis no Select', async () => {
+    render(<PriceTable items={mockItems} />);
+
+    const categorySelect = screen.getByRole('combobox', { name: /category/i });
+    expect(categorySelect).toBeInTheDocument();
+  });
+});

--- a/src/test/catalog.test.ts
+++ b/src/test/catalog.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { ITEM_IDS, ITEM_CATALOG } from '@/data/constants';
+
+describe('ITEM_CATALOG integrity', () => {
+  it('ITEM_IDS tem ≥400 IDs únicos (AC1)', () => {
+    expect(new Set(ITEM_IDS).size).toBeGreaterThanOrEqual(400);
+  });
+
+  it('ITEM_IDS não tem duplicatas (AC2)', () => {
+    expect(ITEM_IDS.length).toBe(new Set(ITEM_IDS).size);
+  });
+
+  it('ITEM_CATALOG tem ≥10 categorias', () => {
+    expect(Object.keys(ITEM_CATALOG).length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('ITEM_IDS é derivado de ITEM_CATALOG', () => {
+    const fromCatalog = Object.values(ITEM_CATALOG).flatMap(c => c.ids);
+    expect(ITEM_IDS).toEqual(fromCatalog);
+  });
+
+  it('todas as categorias têm label não-vazio', () => {
+    for (const [key, cat] of Object.entries(ITEM_CATALOG)) {
+      expect(cat.label, `categoria ${key}`).toBeTruthy();
+      expect(cat.ids.length, `categoria ${key}`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/test/market.api.batch.test.ts
+++ b/src/test/market.api.batch.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const MOCK_IDS = Array.from({ length: 200 }, (_, i) => `T4_ITEM_${i}`);
+
+vi.mock('@/data/constants', () => ({
+  ITEM_IDS: MOCK_IDS,
+  ITEM_NAMES: {},
+  ITEM_CATALOG: { mock: { label: 'Mock', ids: MOCK_IDS } },
+}));
+
+vi.mock('@/services/alert.storage', () => {
+  function MockAlertStorageService() {
+    return {
+      getAlerts: vi.fn().mockReturnValue([]),
+      saveAlert: vi.fn(),
+      deleteAlert: vi.fn(),
+    };
+  }
+  return { AlertStorageService: MockAlertStorageService };
+});
+
+vi.mock('@/services/market.mock', () => {
+  function MockMarketService() {
+    return { getItems: vi.fn().mockResolvedValue([]) };
+  }
+  return { MockMarketService };
+});
+
+describe('ApiMarketService — batch loading', () => {
+  let service: import('@/services/market.api').ApiMarketService;
+
+  beforeEach(async () => {
+    const { ApiMarketService } = await import('@/services/market.api');
+    service = new ApiMarketService();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('getItems() com 200 IDs faz ≥2 fetches de prices (AC3)', async () => {
+    // Given
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue([]),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    // When
+    await service.getItems();
+
+    // Then: 2 batches de 100 items = 2 chamadas de price + N de history
+    const priceCalls = fetchSpy.mock.calls.filter(([url]) =>
+      (url as string).includes('/stats/prices/')
+    );
+    expect(priceCalls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('falha em 1 batch não cancela os outros batches (AC4)', async () => {
+    // Given: 200 items = 2 batches; batch 1 falha, batch 2 retorna 1 item
+    const validRecord = {
+      item_id: 'T4_ITEM_100',
+      city: 'Caerleon',
+      quality: 1,
+      sell_price_min: 50000,
+      sell_price_min_date: '2026-03-14T10:00:00',
+      buy_price_max: 40000,
+      buy_price_max_date: '2026-03-14T09:00:00',
+    };
+
+    let priceCallIndex = 0;
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      if ((url as string).includes('/stats/prices/')) {
+        priceCallIndex++;
+        if (priceCallIndex === 1) {
+          return Promise.resolve({ ok: false, status: 500, json: vi.fn() });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: vi.fn().mockResolvedValue([validRecord]),
+        });
+      }
+      return Promise.resolve({ ok: true, json: vi.fn().mockResolvedValue([]) });
+    }));
+
+    // When
+    const items = await service.getItems();
+
+    // Then: itens do batch 2 aparecem no resultado mesmo com batch 1 falhando
+    expect(items.some(i => i.itemId === 'T4_ITEM_100')).toBe(true);
+  });
+});
+
+describe('withConcurrency', () => {
+  it('mantém no máximo limit tasks simultâneas (AC5)', async () => {
+    // Given
+    const { withConcurrency } = await import('@/services/market.api');
+    let concurrent = 0;
+    let maxConcurrent = 0;
+
+    const makeTask = () => async () => {
+      concurrent++;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await new Promise(resolve => setTimeout(resolve, 10));
+      concurrent--;
+    };
+
+    const LIMIT = 3;
+    const tasks = Array.from({ length: 9 }, makeTask);
+
+    // When
+    await withConcurrency(tasks, LIMIT);
+
+    // Then
+    expect(maxConcurrent).toBeLessThanOrEqual(LIMIT);
+    expect(maxConcurrent).toBeGreaterThan(0);
+  }, 5000);
+
+  it('chunkArray divide array em chunks do tamanho correto', async () => {
+    const { chunkArray } = await import('@/services/market.api');
+    const arr = Array.from({ length: 250 }, (_, i) => i);
+
+    const chunks = chunkArray(arr, 100);
+
+    expect(chunks.length).toBe(3);
+    expect(chunks[0].length).toBe(100);
+    expect(chunks[1].length).toBe(100);
+    expect(chunks[2].length).toBe(50);
+  });
+});


### PR DESCRIPTION
## Resumo

- Expande o catálogo de itens rastreados de ~52 para **450 IDs únicos** (T4–T8 em 17 categorias: armas, armaduras, off-hands, bags, capes e resources)
- Introduz batch loading com concorrência controlada — `getItems()` processa lotes de 100 itens com `withConcurrency(limit=3)`, respeitando o rate limit de 180 req/min da API
- Adiciona filtro de categoria client-side no `PriceTable` — sem re-fetch

## Mudanças técnicas

| Arquivo | O que mudou |
|---------|------------|
| `src/data/constants.ts` | `ITEM_CATALOG` (17 categorias) + `ITEM_IDS` derivado (450 IDs) + `ITEM_NAMES` programático |
| `src/services/market.api.ts` | `chunkArray`, `withConcurrency` exportados; `getItems()` com batch loading, AbortController único, deduplicação cross-batch |
| `src/components/dashboard/PriceTable.tsx` | `<Select aria-label="Category">` com filtro client-side |
| `src/test/catalog.test.ts` | AC1 (≥400 IDs únicos) + AC2 (sem duplicatas) |
| `src/test/market.api.batch.test.ts` | AC3/AC4/AC5: batching, resiliência, concorrência |
| `src/test/PriceTable.test.tsx` | AC6: Select de categoria acessível |

## Como testar

- [ ] `npm run test` — 65/65 passando
- [ ] `npm run lint && npm run build` — sem erros
- [ ] `VITE_USE_REAL_API=true npm run dev` — dashboard carrega >100 itens, filtro de categoria funcional
- [ ] Devtools Network: verificar ≥2 requests para `/stats/prices/` por refresh

## Riscos residuais

- Bundle de `constants.ts` cresce ~30–50 KB (gzip: ~5–8 KB) — aceitável
- Rate limit: 5 price batches + 35 history requests por refresh; dentro dos limites com staleTime de 15 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)