### PR TITLE
feat(market.api): add fetchWithRetry with exponential backoff

### DIFF
--- a/features/backoff-exponencial/REPORT.md
+++ b/features/backoff-exponencial/REPORT.md
@@ -1,0 +1,50 @@
+---
+feature: backoff-exponencial
+debt_ref: DEBT-P1-001
+status: READY_FOR_COMMIT
+date: 2026-03-16
+---
+
+# REPORT — Backoff Exponencial em market.api.ts
+
+## Resumo executivo
+
+Implementação de retry com backoff exponencial e jitter nas chamadas de fetch de `market.api.ts`. A função `fetchWithRetry` foi extraída como utilitário exportado e integrada em `fetchPricesBatch` e `fetchHistoryBatch`. Todos os 5 critérios de aceite da SPEC foram atendidos. 79/79 testes passando, lint limpo, build limpo.
+
+## Escopo alterado
+
+| Arquivo | Tipo de alteração |
+|---------|------------------|
+| `src/services/market.api.ts` | Adição de `fetchWithRetry`, `RETRY_MAX_ATTEMPTS`, `RETRY_BASE_DELAY_MS`; substituição de `fetch` direto em `fetchPricesBatch` e `fetchHistoryBatch` |
+| `src/test/market.api.retry.test.ts` | Novo — 14 testes cobrindo AC-1, AC-2, AC-4, AC-5 |
+| `src/test/market.api.test.ts` | Correção de 4 testes pré-existentes para compatibilidade com fake timers após introdução do retry |
+
+## Critérios de aceite
+
+| AC | Descrição | Status |
+|----|-----------|--------|
+| AC-1 | `fetchWithRetry` exportado; `fetchPricesBatch`/`fetchHistoryBatch` delegam para ela | PASS |
+| AC-2 | Retry em 429/5xx/network; não-retry em 4xx/AbortError | PASS |
+| AC-3 | Backoff `baseDelay * 2^attempt + jitter`; constantes `RETRY_MAX_ATTEMPTS=3`, `RETRY_BASE_DELAY_MS=500` exportadas | PASS |
+| AC-4 | `AbortSignal` abortado interrompe retentativas e rejeita com `AbortError` | PASS |
+| AC-5 | `fetchHistoryBatch` usa `fetchWithRetry`; erros após retries continuam silenciados | PASS |
+
+## Validações executadas
+
+- **quality-gate**: `QUALITY_PASS` — lint 0 erros, build limpo, 79/79 testes
+- **security-review**: `SECURITY_PASS` — mudança restrita a lógica de retry client-side sobre URLs fixas; sem secrets, sem CI/CD, sem superfície de ataque relevante
+- **code-review**: `SKIPPED` — diff focado, lógica direta, sem ramificações não óbvias
+
+## Riscos residuais
+
+- `fetchWithRetry` aceita URL arbitrária — não relevante em contexto browser com callers restritos a constantes hardcoded; sem vetor SSRF aplicável
+- `response.json()` sem limite de payload — pré-existente, fora do escopo desta feature
+
+## Follow-ups
+
+- AC-3 (jitter) não tem teste unitário direto — coberto indiretamente pelos testes de contagem de tentativas; pode ser adicionado se desejar cobertura explícita
+- `DEBT-P1-001` encerrado após merge
+
+## Status final
+
+**READY_FOR_COMMIT**

--- a/features/backoff-exponencial/SPEC.md
+++ b/features/backoff-exponencial/SPEC.md
@@ -1,0 +1,48 @@
+---
+feature: backoff-exponencial
+status: draft
+created: 2026-03-16
+debt_ref: DEBT-P1-001
+---
+
+# SPEC — Backoff Exponencial em market.api.ts
+
+## Contexto
+
+A API pública do Albion Online (`west.albion-online-data.com`) possui rate limiting não documentado (~180 req/min estimado). Atualmente `fetchPricesBatch` e `fetchHistoryBatch` falham silenciosamente sem retentativa. Erros transientes (rede, 429, 5xx) resultam em dados incompletos ou fallback para mock sem qualquer tentativa de recuperação.
+
+## Objetivo
+
+Adicionar retentativas com backoff exponencial às chamadas de fetch em `market.api.ts`, reduzindo falhas transientes sem aumentar pressão sobre o rate limit.
+
+## Escopo
+
+Apenas `src/services/market.api.ts`. Sem alteração em componentes, hooks, testes E2E ou configuração.
+
+## Critérios de aceite
+
+### AC-1 — `fetchWithRetry` como utilitário exportado
+- Uma função `fetchWithRetry(url, options, retryConfig?)` é exportada de `market.api.ts`
+- Encapsula a lógica de retry; `fetchPricesBatch` e `fetchHistoryBatch` delegam para ela
+
+### AC-2 — Retentativa em erros transientes
+- Retentar em: HTTP 429, HTTP 5xx (500–599), erro de rede (falha de `fetch()`)
+- Não retentar em: `AbortError`, HTTP 4xx (exceto 429), HTTP 2xx/3xx
+
+### AC-3 — Backoff exponencial com jitter
+- Delay entre tentativas: `baseDelay * 2^attempt + jitter` (jitter: 0–100ms aleatório)
+- Parâmetros exportados como constantes: `RETRY_MAX_ATTEMPTS = 3`, `RETRY_BASE_DELAY_MS = 500`
+
+### AC-4 — Respeito ao AbortSignal
+- Se o `AbortSignal` estiver abortado antes ou durante uma retentativa, interrompe imediatamente sem nova tentativa
+- Deve rejeitar com `AbortError` (não engolir o erro de abort)
+
+### AC-5 — História best-effort mantida
+- `fetchHistoryBatch` usa `fetchWithRetry` internamente
+- Erros após esgotar retentativas continuam sendo silenciados (catch externo inalterado)
+
+## Fora do escopo
+- Cache com TTL em localStorage
+- Circuit breaker
+- UI de feedback de retentativa
+- Alteração no timeout global (15s via AbortController)

--- a/src/services/market.api.ts
+++ b/src/services/market.api.ts
@@ -11,6 +11,54 @@ const HISTORY_URL = 'https://west.albion-online-data.com/api/v2/stats/history';
 
 export const BATCH_SIZE = 100;
 export const HISTORY_CONCURRENCY = 3;
+export const RETRY_MAX_ATTEMPTS = 3;
+export const RETRY_BASE_DELAY_MS = 500;
+
+function isRetryable(status: number): boolean {
+  return status === 429 || (status >= 500 && status <= 599);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function fetchWithRetry(
+  url: string,
+  options?: RequestInit,
+  retryConfig?: { maxAttempts?: number; baseDelayMs?: number }
+): Promise<Response> {
+  const maxAttempts = retryConfig?.maxAttempts ?? RETRY_MAX_ATTEMPTS;
+  const baseDelayMs = retryConfig?.baseDelayMs ?? RETRY_BASE_DELAY_MS;
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxAttempts; attempt++) {
+    if (options?.signal?.aborted) {
+      throw new DOMException('The operation was aborted.', 'AbortError');
+    }
+
+    let response: Response | undefined;
+    try {
+      response = await fetch(url, options);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') throw err;
+      lastError = err;
+    }
+
+    if (response) {
+      if (response.ok) return response;
+      if (!isRetryable(response.status)) throw new Error(`HTTP ${response.status}`);
+      lastError = new Error(`HTTP ${response.status}`);
+    }
+
+    if (attempt < maxAttempts) {
+      const jitter = Math.floor(Math.random() * 100);
+      await delay(baseDelayMs * Math.pow(2, attempt) + jitter);
+    }
+  }
+
+  throw lastError;
+}
 
 const LOCATIONS = [
   'Caerleon',
@@ -65,8 +113,7 @@ export class ApiMarketService implements MarketService {
   private async fetchPricesBatch(itemIds: string[], signal?: AbortSignal): Promise<AlbionPriceRecord[]> {
     const locationsParam = LOCATIONS.join(',');
     const url = `${BASE_URL}/${itemIds.join(',')}.json?locations=${locationsParam}&qualities=1,2,3,4,5`;
-    const response = await fetch(url, { signal });
-    if (!response.ok) throw new Error(`Albion API error: ${response.status}`);
+    const response = await fetchWithRetry(url, { signal });
     const raw: unknown[] = await response.json();
     return raw
       .map(r => {
@@ -80,8 +127,7 @@ export class ApiMarketService implements MarketService {
     const map: HistoryMap = new Map();
     try {
       const url = `${HISTORY_URL}/${itemIds.join(',')}.json?locations=${city}&qualities=1&time-scale=1`;
-      const response = await fetch(url);
-      if (!response.ok) throw new Error(`History API error: ${response.status}`);
+      const response = await fetchWithRetry(url);
       const raw: unknown[] = await response.json();
       for (const record of raw) {
         const result = AlbionHistoryRecordSchema.safeParse(record);

--- a/src/test/market.api.retry.test.ts
+++ b/src/test/market.api.retry.test.ts
@@ -1,0 +1,242 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Todos os testes neste arquivo são RED — fetchWithRetry não existe ainda
+
+// Mock global necessário para AC-4 e AC-5 (evita erros de exports em mockData.ts)
+vi.mock('@/data/constants', () => ({
+  ITEM_IDS: ['T4_MAIN_SWORD'],
+  ITEM_NAMES: { T4_MAIN_SWORD: 'Broadsword T4' },
+  ITEM_CATALOG: { weapons: { label: 'Weapons', ids: ['T4_MAIN_SWORD'] } },
+  cities: ['Caerleon'],
+  tiers: ['T4'],
+  qualities: ['Normal'],
+}));
+
+vi.mock('@/services/alert.storage', () => {
+  function AlertStorageService() {
+    return { getAlerts: vi.fn().mockReturnValue([]), saveAlert: vi.fn(), deleteAlert: vi.fn() };
+  }
+  return { AlertStorageService };
+});
+
+describe('fetchWithRetry — AC-1: exportação e constantes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('fetchWithRetry é exportado de market.api', async () => {
+    const mod = await import('@/services/market.api');
+    expect(typeof (mod as any).fetchWithRetry).toBe('function');
+  });
+
+  it('RETRY_MAX_ATTEMPTS é exportado com valor 3', async () => {
+    const { RETRY_MAX_ATTEMPTS } = await import('@/services/market.api') as any;
+    expect(RETRY_MAX_ATTEMPTS).toBe(3);
+  });
+
+  it('RETRY_BASE_DELAY_MS é exportado com valor 500', async () => {
+    const { RETRY_BASE_DELAY_MS } = await import('@/services/market.api') as any;
+    expect(RETRY_BASE_DELAY_MS).toBe(500);
+  });
+});
+
+describe('fetchWithRetry — AC-2: quais erros disparam retry', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('retorna response imediatamente quando ok=true (sem retry)', async () => {
+    const { fetchWithRetry } = await import('@/services/market.api') as any;
+    const mockResponse = { ok: true, status: 200 };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+    const result = await fetchWithRetry('https://example.com');
+
+    expect(result).toBe(mockResponse);
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+  });
+
+  it('retenta em HTTP 429 até esgotar tentativas', async () => {
+    vi.useFakeTimers();
+    const { fetchWithRetry, RETRY_MAX_ATTEMPTS } = await import('@/services/market.api') as any;
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 429 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = fetchWithRetry('https://example.com');
+    const assertion = expect(promise).rejects.toThrow();
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(fetchMock).toHaveBeenCalledTimes(RETRY_MAX_ATTEMPTS + 1);
+  });
+
+  it('retenta em HTTP 500', async () => {
+    vi.useFakeTimers();
+    const { fetchWithRetry, RETRY_MAX_ATTEMPTS } = await import('@/services/market.api') as any;
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = fetchWithRetry('https://example.com');
+    const assertion = expect(promise).rejects.toThrow();
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(fetchMock).toHaveBeenCalledTimes(RETRY_MAX_ATTEMPTS + 1);
+  });
+
+  it('retenta em HTTP 503', async () => {
+    vi.useFakeTimers();
+    const { fetchWithRetry, RETRY_MAX_ATTEMPTS } = await import('@/services/market.api') as any;
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = fetchWithRetry('https://example.com');
+    const assertion = expect(promise).rejects.toThrow();
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(fetchMock).toHaveBeenCalledTimes(RETRY_MAX_ATTEMPTS + 1);
+  });
+
+  it('retenta em erro de rede (fetch rejeita)', async () => {
+    vi.useFakeTimers();
+    const { fetchWithRetry, RETRY_MAX_ATTEMPTS } = await import('@/services/market.api') as any;
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = fetchWithRetry('https://example.com');
+    const assertion = expect(promise).rejects.toThrow('Failed to fetch');
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(fetchMock).toHaveBeenCalledTimes(RETRY_MAX_ATTEMPTS + 1);
+  });
+
+  it('NÃO retenta em HTTP 400', async () => {
+    vi.useFakeTimers();
+    const { fetchWithRetry } = await import('@/services/market.api') as any;
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 400 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = fetchWithRetry('https://example.com');
+    const assertion = expect(promise).rejects.toThrow();
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('NÃO retenta em HTTP 404', async () => {
+    vi.useFakeTimers();
+    const { fetchWithRetry } = await import('@/services/market.api') as any;
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = fetchWithRetry('https://example.com');
+    const assertion = expect(promise).rejects.toThrow();
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retorna response quando retry bem-sucedido (429 → ok)', async () => {
+    vi.useFakeTimers();
+    const { fetchWithRetry } = await import('@/services/market.api') as any;
+    const successResponse = { ok: true, status: 200 };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 429 })
+      .mockResolvedValueOnce(successResponse);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = fetchWithRetry('https://example.com');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toBe(successResponse);
+  });
+});
+
+describe('fetchWithRetry — AC-4: AbortSignal', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('NÃO retenta em AbortError — rejeita imediatamente', async () => {
+    const { fetchWithRetry } = await import('@/services/market.api') as any;
+    const abortError = new DOMException('The operation was aborted.', 'AbortError');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortError));
+
+    // AbortError rejeita imediatamente — sem timers necessários
+    await expect(fetchWithRetry('https://example.com')).rejects.toMatchObject({ name: 'AbortError' });
+
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+  });
+
+  it('para retentativas quando signal é abortado após 1ª tentativa', async () => {
+    vi.useFakeTimers();
+    const { fetchWithRetry } = await import('@/services/market.api') as any;
+    const controller = new AbortController();
+
+    const fetchMock = vi.fn().mockImplementation(() => {
+      controller.abort();
+      return Promise.resolve({ ok: false, status: 503 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = fetchWithRetry('https://example.com', { signal: controller.signal });
+    // Anexa o handler ANTES de avançar os timers para evitar unhandled rejection
+    const assertion = expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+    await vi.runAllTimersAsync().catch(() => {});
+    await assertion;
+
+    // Deve ter parado após a 1ª tentativa por causa do abort
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('fetchWithRetry — AC-5: fetchHistoryBatch mantém comportamento best-effort', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('getItems() resolve mesmo quando todas as chamadas de histórico falham após retries', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if ((url as string).includes('/stats/prices/')) {
+        return Promise.resolve({
+          ok: true,
+          json: vi.fn().mockResolvedValue([{
+            item_id: 'T4_MAIN_SWORD',
+            city: 'Caerleon',
+            quality: 1,
+            sell_price_min: 50000,
+            sell_price_min_date: '2026-03-14T10:00:00',
+            buy_price_max: 40000,
+            buy_price_max_date: '2026-03-14T09:00:00',
+          }]),
+        });
+      }
+      // Todas as chamadas de histórico falham com 503 (retenta internamente e depois silencia)
+      return Promise.resolve({ ok: false, status: 503 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { ApiMarketService } = await import('@/services/market.api');
+    const service = new ApiMarketService();
+
+    const promise = service.getItems();
+    await vi.runAllTimersAsync();
+    const items = await promise;
+
+    expect(items.length).toBeGreaterThan(0);
+    expect(items[0].itemId).toBe('T4_MAIN_SWORD');
+  }, 15000);
+});

--- a/src/test/market.api.test.ts
+++ b/src/test/market.api.test.ts
@@ -87,29 +87,37 @@ describe('ApiMarketService', () => {
 
     it('retorna mock data em erro de rede', async () => {
       // Given
+      vi.useFakeTimers();
       vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
 
-      // When
-      const items = await service.getItems();
+      // When — fetchWithRetry retenta antes de esgotar; fake timers avançam os delays
+      const promise = service.getItems();
+      await vi.runAllTimersAsync();
+      const items = await promise;
 
       // Then
       expect(items.length).toBeGreaterThan(0);
-    });
+      vi.useRealTimers();
+    }, 10_000);
 
     it('retorna mock data quando API retorna status != 200', async () => {
       // Given
+      vi.useFakeTimers();
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
         ok: false,
         status: 503,
         json: vi.fn().mockResolvedValue([]),
       }));
 
-      // When
-      const items = await service.getItems();
+      // When — 503 é retentável; fake timers avançam os delays de backoff
+      const promise = service.getItems();
+      await vi.runAllTimersAsync();
+      const items = await promise;
 
       // Then
       expect(items.length).toBeGreaterThan(0);
-    });
+      vi.useRealTimers();
+    }, 10_000);
 
     it('retorna mock data em timeout (>15s)', async () => {
       // Given
@@ -187,20 +195,25 @@ describe('ApiMarketService', () => {
 
     it('não chama console.warn nem console.error em erro de rede (fallback)', async () => {
       // Given
+      vi.useFakeTimers();
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
 
       // When
-      await service.getItems();
+      const promise = service.getItems();
+      await vi.runAllTimersAsync();
+      await promise;
 
       // Then
       expect(warnSpy).not.toHaveBeenCalled();
       expect(errorSpy).not.toHaveBeenCalled();
-    });
+      vi.useRealTimers();
+    }, 10_000);
 
     it('não chama console.warn em falha de histórico por cidade', async () => {
       // Given
+      vi.useFakeTimers();
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       let callCount = 0;
       vi.stubGlobal('fetch', vi.fn().mockImplementation(() => {
@@ -212,11 +225,14 @@ describe('ApiMarketService', () => {
       }));
 
       // When
-      await service.getItems();
+      const promise = service.getItems();
+      await vi.runAllTimersAsync();
+      await promise;
 
       // Then
       expect(warnSpy).not.toHaveBeenCalled();
-    });
+      vi.useRealTimers();
+    }, 10_000);
   });
 
   describe('albionRecordToMarketItem()', () => {


### PR DESCRIPTION
## Summary

- Extrai `fetchWithRetry` como utilitário exportado de `market.api.ts` com retry automático em erros transientes (HTTP 429, 5xx, falha de rede)
- Backoff exponencial com jitter: `baseDelay * 2^attempt + random(0–100ms)`; parâmetros: `RETRY_MAX_ATTEMPTS=3`, `RETRY_BASE_DELAY_MS=500ms`
- `fetchPricesBatch` e `fetchHistoryBatch` delegam para `fetchWithRetry`; comportamento best-effort do histórico preservado
- Fecha `DEBT-P1-001`

## Validação

- 79/79 testes passando (14 novos em `market.api.retry.test.ts`)
- `npm run lint` — 0 erros
- `npm run build` — limpo
- `QUALITY_PASS` · `SECURITY_PASS`

## Como testar

1. `npm run test` → 79/79
2. `VITE_USE_REAL_API=true npm run dev` → verificar que preços carregam normalmente com throttling de rede simulado (DevTools → Network → Slow 3G)

🤖 Generated with [Claude Code](https://claude.com/claude-code)