### PR TITLE
feat(tsconfig): ativar noImplicitAny e strictNullChecks (strict mode …

### DIFF
--- a/docs/adr/ADR-006-typescript-strict-mode-gradual-migration.md
+++ b/docs/adr/ADR-006-typescript-strict-mode-gradual-migration.md
@@ -1,0 +1,30 @@
+# ADR-006 — Migração gradual para TypeScript strict mode
+
+**Status:** Aceito
+**Data:** 2026-03-16
+
+## Contexto
+
+O projeto foi iniciado com `noImplicitAny: false` e `strictNullChecks: false`, permitindo que erros de tipo silenciosos proliferassem na codebase. A análise de março/2026 identificou isso como único DEBT-P0 do projeto. Habilitar strict mode de forma abrupta em toda a codebase seria arriscado devido ao volume de arquivos e à ausência de mapeamento prévio de erros.
+
+## Decisão
+
+Migração gradual em iterações por camada:
+
+1. **Iteração 1 (concluída):** Ativar `noImplicitAny: true` e `strictNullChecks: true` globalmente. Validar que toda a codebase compila sem erros — se limpa, sem supressões. Se necessário, suprimir com `// @ts-ignore // TODO: strict-mode-iteration-N` fora da camada alvo.
+2. **Iterações futuras:** `src/hooks/` → `src/pages/` → `src/components/` → habilitar `strict: true` completo.
+
+Flags **não** ativados nesta iteração (cobertos por `strict: true` completo, adiados): `strictFunctionTypes`, `strictBindCallApply`, `strictPropertyInitialization`, `useUnknownInCatchVariables`.
+
+## Consequências
+
+- Erros de tipo implícito (`any`) e de nullabilidade passam a ser detectados em tempo de compilação em toda a codebase.
+- A codebase atual (`src/services/` e demais) já era type-safe — nenhuma supressão foi necessária na iteração 1.
+- PRs futuros que introduzirem `any` implícito ou null unsafe serão bloqueados pelo compilador.
+- `strict: true` completo exigirá uma iteração dedicada quando hooks e páginas forem auditados.
+
+## Alternativas consideradas
+
+- **`strict: true` imediato:** rejeitado — risco de mascarar erros com supressões em massa sem revisão adequada.
+- **tsconfig por camada (project references):** rejeitado — aumenta complexidade de build sem ganho proporcional; migração global mais simples se a codebase já for compatível.
+- **Manter flags desativados:** rejeitado — débito P0; erros de tipo em `src/services/` têm impacto direto em runtime.

--- a/features/typescript-strict-mode/REPORT.md
+++ b/features/typescript-strict-mode/REPORT.md
@@ -1,0 +1,58 @@
+# REPORT — TypeScript Strict Mode (primeira iteração: src/services/)
+
+**Data:** 2026-03-16
+**Branch:** feat/typescript-strict-mode
+**Status:** READY_FOR_COMMIT
+
+---
+
+## Objetivo
+
+Ativar `noImplicitAny: true` e `strictNullChecks: true` em `tsconfig.app.json` e `tsconfig.json`, eliminando o único DEBT-P0 identificado na análise de março/2026. Escopo inicial: validação sobre `src/services/`.
+
+---
+
+## Escopo alterado
+
+| Arquivo | Tipo de mudança |
+|---|---|
+| `tsconfig.app.json` | `noImplicitAny: false → true`; `strictNullChecks: true` adicionado |
+| `tsconfig.json` | `noImplicitAny: false → true`; `strictNullChecks: false → true` |
+| `src/test/tsconfig.strict.test.ts` | Novo — 4 testes de AC-1 (leitura dos flags nos tsconfigs) |
+
+Nenhum arquivo de `src/services/` foi alterado — todos os 7 arquivos já eram type-safe.
+
+---
+
+## Validações executadas
+
+| Gate | Resultado |
+|---|---|
+| `tsc --noEmit` | ✅ 0 erros em toda a codebase |
+| `npm run build` | ✅ clean — bundle 393 kB sem erros |
+| `npm run test` | ✅ 85/85 passando (81 anteriores + 4 novos) |
+| `npm run lint` | ✅ 0 erros — 7 warnings pré-existentes em `src/components/ui/` |
+| quality-gate | `QUALITY_PASS` |
+| security-review | `SKIPPED — justificativa: mudança de configuração de compilador; não toca CI/CD, auth, infra, APIs públicas ou skills` |
+| code-review | `SKIPPED — diff trivial: 4 linhas em 2 arquivos de configuração` |
+
+---
+
+## Riscos residuais
+
+- **`strict: false` ainda presente em `tsconfig.app.json`** — flags `strictFunctionTypes`, `strictBindCallApply`, `strictPropertyInitialization` e similares continuam desativados. Iterações futuras devem avaliá-los.
+- **Demais diretórios não validados** — `src/components/`, `src/hooks/`, `src/pages/`, `src/lib/`, `src/data/` passam a ser compilados com os novos flags mas não foram auditados explicitamente. A ausência de erros no `tsc --noEmit` confirma compatibilidade, mas revisão direcionada é recomendada em iteração futura.
+
+---
+
+## Follow-ups
+
+1. **Iteração 2 — strict mode em `src/hooks/`**: próximo escopo natural após serviços.
+2. **Avaliar `strict: true` completo**: quando hooks e páginas estiverem limpos.
+3. **`noUnusedLocals` e `noUnusedParameters`**: ainda `false`; baixa prioridade mas úteis para higiene.
+
+---
+
+## Recomendação final
+
+`READY_FOR_COMMIT`

--- a/features/typescript-strict-mode/SPEC.md
+++ b/features/typescript-strict-mode/SPEC.md
@@ -1,0 +1,61 @@
+# SPEC — TypeScript Strict Mode (primeira iteração: src/services/)
+
+**Status:** Draft
+**Data:** 2026-03-16
+**Autor:** Claude
+
+---
+
+## Contexto e Motivação
+
+O projeto tem `noImplicitAny: false` e `strictNullChecks: false` nos dois tsconfigs (`tsconfig.json` e `tsconfig.app.json`), o que permite erros de tipo silenciosos em toda a codebase. Isso é o único DEBT-P0 identificado na análise de março/2026. A migração começa por `src/services/` — a camada mais crítica do projeto — onde erros de tipo têm maior impacto em runtime.
+
+## Problema a Resolver
+
+Erros de tipo em `src/services/` passam silenciosamente pelo compilador, especialmente:
+- parâmetros sem tipo explícito (implícito `any`)
+- valores possivelmente `null`/`undefined` acessados sem guard
+
+## Fora do Escopo
+
+- Ativar `strict: true` completo (que inclui `strictFunctionTypes`, `strictBindCallApply`, etc.)
+- Corrigir erros de tipo em `src/components/`, `src/hooks/`, `src/pages/`, `src/lib/`, `src/data/`
+- Adicionar cobertura de testes além do que já existe
+- Migrar para `noUnusedLocals` ou `noUnusedParameters`
+
+## Critérios de Aceitação
+
+### Cenário 1: Flags ativados no tsconfig
+**Given** os arquivos `tsconfig.json` e `tsconfig.app.json` com `noImplicitAny: false` e `strictNullChecks: false`
+**When** a feature for implementada
+**Then** ambos os arquivos passam a ter `noImplicitAny: true` e `strictNullChecks: true`
+
+### Cenário 2: src/services/ compila sem erros de tipo
+**Given** os flags `noImplicitAny: true` e `strictNullChecks: true` ativados
+**When** o TypeScript compila os 7 arquivos de `src/services/`
+**Then** nenhum erro de tipo é reportado nos arquivos da camada de serviços
+
+### Cenário 3: Build de produção passa sem erros
+**Given** os flags ativados e os erros de serviços corrigidos
+**When** `npm run build` é executado
+**Then** o build completa sem erros — erros em arquivos fora de `src/services/` são suprimidos com `// @ts-ignore` acompanhado de comentário `// TODO: strict-mode-iteration-N`
+
+### Cenário 4: Testes existentes continuam passando
+**Given** o código de serviços corrigido para strict mode
+**When** `npm run test` é executado
+**Then** todos os 81 testes passam sem regressão
+
+## Dependências
+
+- `tsconfig.json` e `tsconfig.app.json` na raiz do projeto
+- 7 arquivos em `src/services/`: `market.service.ts`, `market.api.ts`, `market.api.types.ts`, `market.mock.ts`, `alert.engine.ts`, `alert.storage.ts`, `index.ts`
+
+## Riscos e Incertezas
+
+- Quantidade exata de erros fora de `src/services/` ainda não mapeada — pode ser maior que o esperado, aumentando o esforço de supressão
+- Supressões com `@ts-ignore` em arquivos externos podem mascarar erros reais — mitigado pelo comentário `TODO` e iterações futuras
+
+## Referências
+
+- `ANALYSIS_REPORT.md` — DEBT-P0 identificado em 2026-03-16
+- `memory/MEMORY.md` — "TypeScript strict mode: desativado — único P0 restante; migração gradual pendente iniciando por `src/services/`"

--- a/src/test/tsconfig.strict.test.ts
+++ b/src/test/tsconfig.strict.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// AC-1: ambos os tsconfigs devem ter noImplicitAny e strictNullChecks ativados
+// AC-2 e AC-3 são validados pela ausência de erros em npm run build
+
+function readTsconfig(filename: string) {
+  const raw = readFileSync(resolve(process.cwd(), filename), 'utf-8');
+  // tsconfig aceita comentários — removê-los antes de parsear como JSON
+  const cleaned = raw.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+  return JSON.parse(cleaned);
+}
+
+describe('tsconfig.app.json — strict mode flags (AC-1)', () => {
+  const config = readTsconfig('tsconfig.app.json');
+  const opts = config.compilerOptions;
+
+  it('deve ter noImplicitAny ativado', () => {
+    expect(opts.noImplicitAny).toBe(true);
+  });
+
+  it('deve ter strictNullChecks ativado', () => {
+    expect(opts.strictNullChecks).toBe(true);
+  });
+});
+
+describe('tsconfig.json — strict mode flags (AC-1)', () => {
+  const config = readTsconfig('tsconfig.json');
+  const opts = config.compilerOptions;
+
+  it('deve ter noImplicitAny ativado', () => {
+    expect(opts.noImplicitAny).toBe(true);
+  });
+
+  it('deve ter strictNullChecks ativado', () => {
+    expect(opts.strictNullChecks).toBe(true);
+  });
+});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,7 +18,8 @@
     "strict": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
     "noFallthroughCasesInSwitch": false,
 
     "baseUrl": ".",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,11 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noUnusedParameters": false,
     "skipLibCheck": true,
     "allowJs": true,
     "noUnusedLocals": false,
-    "strictNullChecks": false
+    "strictNullChecks": true
   }
 }


### PR DESCRIPTION
…iteração 1)

- tsconfig.app.json e tsconfig.json: noImplicitAny false→true, strictNullChecks false→true
- src/test/tsconfig.strict.test.ts: 4 testes de AC-1 (85/85 passando)
- docs/adr/ADR-006: registra estratégia de migração gradual por camada
- features/typescript-strict-mode: SPEC.md e REPORT.md

Codebase já era type-safe — nenhuma supressão necessária. Fecha DEBT-P0 identificado na análise de 2026-03-16.