### PR TITLE
feat(cache): cache de dados de mercado com TTL em localStorage

### DIFF
--- a/docs/adr/ADR-007-market-data-cache-ttl-localstorage.md
+++ b/docs/adr/ADR-007-market-data-cache-ttl-localstorage.md
@@ -1,0 +1,49 @@
+# ADR-007 — Cache de dados de mercado com TTL em localStorage
+
+**Status:** Aceito
+**Data:** 2026-03-16
+
+## Contexto
+
+`ApiMarketService.getItems()` busca preços de 450 itens × 7 cidades a cada chamada,
+gerando dezenas de requisições HTTP em paralelo. O carregamento inicial com a API real
+pode levar vários segundos. Os preços do Albion Online têm granularidade de minutos —
+dados com poucos minutos de atraso ainda são úteis para análise de spread.
+
+## Decisão
+
+Introduzir cache de dados de mercado em `localStorage` com TTL de 5 minutos (300 000 ms).
+O módulo `src/services/market.cache.ts` encapsula leitura, escrita e validação via schema
+Zod. A `ApiMarketService.getItems()` verifica o cache antes de qualquer chamada HTTP; em
+cache hit, retorna os dados diretamente. Em cache miss ou expirado, busca da API e
+persiste o resultado. A chave usada é `albion_market_cache`.
+
+## Consequências
+
+- **Positivo:** carregamento do dashboard pode ser imediato em navegações subsequentes
+  dentro da janela de 5 minutos.
+- **Positivo:** reduz chamadas à API pública (`west.albion-online-data.com`), diminuindo
+  risco de atingir rate limits.
+- **Negativo:** dados exibidos podem ter até 5 minutos de atraso em relação ao mercado
+  real — aceitável para o uso analítico atual.
+- **Negativo:** dados são per-device/per-browser; limpeza de storage apaga o cache sem
+  aviso (comportamento idêntico ao ADR-004).
+- **Mitigação de risco de quota:** `writeCache` silencia `QuotaExceededError` — em caso de
+  storage cheio, a feature degrada para o comportamento anterior sem cache, sem erros.
+- **Mitigação de dados corrompidos:** `readCache` valida a estrutura completa com Zod
+  (incluindo campos de `MarketItem`); dados inválidos são tratados como cache miss.
+- `getLastUpdateTime()` reflete `cachedAt` do cache, comunicando ao usuário a idade dos
+  dados exibidos.
+
+## Alternativas consideradas
+
+- **TTL mais curto (1 min):** reduziria o benefício percebido — a busca completa leva
+  mais de 1 min em alguns casos; o cache poderia expirar antes de ser útil.
+- **TTL mais longo (30 min):** dados ficariam desatualizados demais para análise de
+  oportunidades de mercado em tempo real.
+- **Cache em memória (in-process):** perdido a cada reload — benefício limitado para o
+  caso de uso principal (abrir o dashboard pela manhã).
+- **IndexedDB:** API assíncrona e mais complexa sem ganho relevante para o volume de
+  dados atual (~450 itens × 7 cidades).
+- **Service Worker + Cache API:** infra mais robusta mas desnecessária para o escopo
+  front-end apenas do projeto.

--- a/features/cache-ttl-localstorage/REPORT.md
+++ b/features/cache-ttl-localstorage/REPORT.md
@@ -1,0 +1,41 @@
+# REPORT — cache-ttl-localstorage
+
+**Status:** READY_FOR_COMMIT
+**Data:** 2026-03-16
+
+---
+
+## O que mudou
+
+- **`src/services/market.cache.ts`** (novo): módulo de cache com leitura, escrita e validação Zod dos dados. Exporta `CACHE_KEY`, `CACHE_TTL_MS` (300 000 ms), `readCache`, `writeCache`, `isCacheValid` e o tipo `MarketCacheEntry` derivado do schema.
+- **`src/services/market.api.ts`**: `getItems()` verifica o cache antes de chamar a API; `cachedLastUpdate` é sincronizado com `cached.cachedAt` quando o cache é servido. `writeCache` é chamado após fetch bem-sucedido.
+- **`src/test/market.cache.test.ts`** (novo): 17 testes cobrindo AC-1 a AC-5.
+
+---
+
+## Por que mudou
+
+Carregamento inicial com API real era lento (450 itens × 7 cidades). Dados de preços do Albion Online têm granularidade adequada para TTL de 5 minutos — sem perda de utilidade analítica. Fecha DEBT-P1-002.
+
+---
+
+## Como foi validado
+
+- 102/102 testes passando (85 anteriores + 17 novos)
+- `npm run lint`: 0 erros (7 warnings pré-existentes em `src/components/ui/`)
+- `npm run build`: sucesso, bundle inalterado (~394 kB)
+- code-review: REVIEW_OK_WITH_NOTES — riscos #1 (cast sem validação), #2 (QuotaExceededError), #4 (import relativo) resolvidos
+
+---
+
+## Riscos residuais
+
+- **Finding #3 (RISCO baixo):** `cachedLastUpdate` é estado de instância. Em cenário multi-instância (improvável em produção — app usa singleton), o valor pode divergir do cache real. Sem impacto em testes ou uso atual.
+- **Finding #6 (SUGESTÃO):** `isCacheValid` com `expiresAt` malformado retorna `false` por propriedade de `NaN` — comportamento correto mas implícito. Sem risco operacional.
+
+---
+
+## Próximos passos
+
+1. TypeScript strict mode iteração 2 (`src/hooks/`) — ADR-006
+2. Enchanted items (`.@1/.@2/.@3`) no catálogo

--- a/features/cache-ttl-localstorage/SPEC.md
+++ b/features/cache-ttl-localstorage/SPEC.md
@@ -1,0 +1,82 @@
+---
+feature: cache-ttl-localstorage
+status: draft
+created: 2026-03-16
+---
+
+# SPEC — Cache com TTL em localStorage
+
+## Contexto
+
+`ApiMarketService.getItems()` busca dados de preços para 450 itens × 7 cidades a cada chamada.
+Com a API real ativa, o carregamento inicial pode levar vários segundos e gera N requisições HTTP.
+Os preços do Albion Online não mudam com frequência suficiente para justificar refresh contínuo —
+dados de alguns minutos atrás ainda são úteis para análise.
+
+## Objetivo
+
+Introduzir uma camada de cache em `localStorage` na `ApiMarketService` para que dados recentemente
+buscados sejam reutilizados dentro de uma janela de TTL, reduzindo chamadas à API e tempo de carregamento.
+
+## Escopo
+
+- Novo módulo `src/services/market.cache.ts` com a lógica de leitura/escrita de cache
+- Integração na `ApiMarketService.getItems()` — verificar cache antes de buscar
+- `getLastUpdateTime()` reflete o `cachedAt` quando os dados vêm do cache
+- Sem mudanças em UI, hooks ou componentes
+
+## Fora do escopo
+
+- Cache para `getTopProfitable()` (opera sobre `getItems()` — beneficia indiretamente)
+- Cache para histórico de preços (apenas dados de preço corrente)
+- Invalidação manual de cache pela UI
+- Cache em memória (apenas localStorage)
+
+## Acceptance Criteria
+
+### AC-1 — Cache miss: busca API e persiste
+
+Dado que não há cache no localStorage (ou a chave não existe),
+quando `getItems()` for chamado,
+então deve buscar os dados da API, armazená-los no localStorage com `cachedAt` e `expiresAt`,
+e retornar os itens buscados.
+
+### AC-2 — Cache hit: retorna do cache sem chamar API
+
+Dado que existe cache válido (não expirado) no localStorage,
+quando `getItems()` for chamado,
+então deve retornar os dados do cache sem realizar nenhuma chamada HTTP à API de preços.
+
+### AC-3 — Cache expirado: revalida e atualiza
+
+Dado que existe cache no localStorage mas `expiresAt` está no passado,
+quando `getItems()` for chamado,
+então deve buscar novos dados da API, atualizar o cache no localStorage, e retornar os novos itens.
+
+### AC-4 — getLastUpdateTime reflete cachedAt
+
+Dado que os dados são servidos do cache,
+quando `getLastUpdateTime()` for chamado,
+então deve retornar o `cachedAt` do cache (não a hora atual).
+
+### AC-5 — Cache corrompido: trata como miss
+
+Dado que o localStorage contém dados inválidos ou malformados na chave de cache,
+quando `getItems()` for chamado,
+então deve tratar como cache miss, buscar da API normalmente, e sobrescrever o valor corrompido.
+
+## Decisões técnicas
+
+| Decisão | Valor |
+|---------|-------|
+| Chave localStorage | `albion_market_cache` |
+| TTL padrão | 5 minutos (300 000 ms) — exportado como `CACHE_TTL_MS` |
+| Estrutura do cache | `{ data: MarketItem[], cachedAt: string, expiresAt: string }` |
+| Validação do cache | Schema Zod no módulo `market.cache.ts` |
+| Módulo de cache | `src/services/market.cache.ts` — leitura/escrita isoladas |
+
+## Arquivos esperados
+
+- `src/services/market.cache.ts` — leitura, escrita, validação e TTL
+- `src/services/market.api.ts` — integração do cache em `getItems()` e `getLastUpdateTime()`
+- `src/test/market.cache.test.ts` — testes unitários do módulo de cache

--- a/src/services/market.api.ts
+++ b/src/services/market.api.ts
@@ -5,6 +5,7 @@ import type { AlbionPriceRecord } from './market.api.types';
 import { AlertStorageService } from './alert.storage';
 import { ITEM_IDS, ITEM_NAMES } from '@/data/constants';
 import { MockMarketService } from './market.mock';
+import { readCache, writeCache, isCacheValid } from '@/services/market.cache';
 
 const BASE_URL = 'https://west.albion-online-data.com/api/v2/stats/prices';
 const HISTORY_URL = 'https://west.albion-online-data.com/api/v2/stats/history';
@@ -158,6 +159,12 @@ export class ApiMarketService implements MarketService {
   }
 
   async getItems(): Promise<MarketItem[]> {
+    const cached = readCache();
+    if (cached && isCacheValid(cached)) {
+      this.cachedLastUpdate = cached.cachedAt;
+      return cached.data;
+    }
+
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 15_000);
 
@@ -201,10 +208,13 @@ export class ApiMarketService implements MarketService {
 
       const historyMap = await this.buildHistoryMap(batches);
 
-      return items.map(item => {
+      const result = items.map(item => {
         const history = historyMap.get(`${item.itemId}|${item.city}`);
         return history ? { ...item, priceHistory: history } : item;
       });
+
+      writeCache(result);
+      return result;
     } catch {
       clearTimeout(timeoutId);
       return this.fallback.getItems();

--- a/src/services/market.cache.ts
+++ b/src/services/market.cache.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+import type { MarketItem } from '@/data/types';
+
+export const CACHE_KEY = 'albion_market_cache';
+export const CACHE_TTL_MS = 300_000; // 5 minutes
+
+const MarketItemCacheSchema = z.object({
+  itemId: z.string(),
+  itemName: z.string(),
+  city: z.string(),
+  sellPrice: z.number(),
+  buyPrice: z.number(),
+  spread: z.number(),
+  spreadPercent: z.number(),
+  timestamp: z.string(),
+  tier: z.string(),
+  quality: z.string(),
+  priceHistory: z.array(z.number()),
+});
+
+const MarketCacheEntrySchema = z.object({
+  data: z.array(MarketItemCacheSchema),
+  cachedAt: z.string(),
+  expiresAt: z.string(),
+});
+
+export type MarketCacheEntry = z.infer<typeof MarketCacheEntrySchema>;
+
+export function readCache(): MarketCacheEntry | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const result = MarketCacheEntrySchema.safeParse(JSON.parse(raw));
+    if (!result.success) return null;
+    return result.data;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCache(data: MarketItem[]): void {
+  const now = new Date();
+  const entry: MarketCacheEntry = {
+    data,
+    cachedAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + CACHE_TTL_MS).toISOString(),
+  };
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(entry));
+  } catch {
+    // QuotaExceededError or other storage errors — silently skip caching
+  }
+}
+
+export function isCacheValid(entry: MarketCacheEntry): boolean {
+  return new Date(entry.expiresAt).getTime() > Date.now();
+}

--- a/src/test/market.cache.test.ts
+++ b/src/test/market.cache.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { CACHE_KEY, CACHE_TTL_MS, readCache, writeCache, isCacheValid } from '@/services/market.cache';
+import { ApiMarketService } from '@/services/market.api';
+import type { MarketItem } from '@/data/types';
+
+vi.mock('@/services/alert.storage', () => ({
+  AlertStorageService: class {
+    getAlerts = vi.fn().mockReturnValue([]);
+    saveAlert = vi.fn();
+    deleteAlert = vi.fn();
+  },
+}));
+
+const mockItems: MarketItem[] = [
+  {
+    itemId: 'T4_MAIN_SWORD',
+    itemName: 'Broadsword T4',
+    city: 'Caerleon',
+    sellPrice: 50000,
+    buyPrice: 40000,
+    spread: 10000,
+    spreadPercent: 25,
+    timestamp: '2026-03-16T10:00:00',
+    tier: 'T4',
+    quality: 'Normal',
+    priceHistory: [45000, 47000, 50000],
+  },
+];
+
+describe('market.cache — AC-1: writeCache persiste no localStorage', () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it('CACHE_KEY é exportado como string não-vazia', () => {
+    expect(typeof CACHE_KEY).toBe('string');
+    expect(CACHE_KEY.length).toBeGreaterThan(0);
+  });
+
+  it('CACHE_TTL_MS é exportado com valor 300000 (5 min)', () => {
+    expect(CACHE_TTL_MS).toBe(300_000);
+  });
+
+  it('writeCache persiste os dados no localStorage', () => {
+    writeCache(mockItems);
+    const raw = localStorage.getItem(CACHE_KEY);
+    expect(raw).not.toBeNull();
+  });
+
+  it('writeCache armazena a estrutura { data, cachedAt, expiresAt }', () => {
+    const before = Date.now();
+    writeCache(mockItems);
+    const after = Date.now();
+
+    const entry = JSON.parse(localStorage.getItem(CACHE_KEY)!);
+
+    expect(Array.isArray(entry.data)).toBe(true);
+    expect(typeof entry.cachedAt).toBe('string');
+    expect(typeof entry.expiresAt).toBe('string');
+
+    const cachedAtMs = new Date(entry.cachedAt).getTime();
+    expect(cachedAtMs).toBeGreaterThanOrEqual(before);
+    expect(cachedAtMs).toBeLessThanOrEqual(after);
+  });
+
+  it('expiresAt = cachedAt + CACHE_TTL_MS', () => {
+    writeCache(mockItems);
+    const entry = JSON.parse(localStorage.getItem(CACHE_KEY)!);
+    const diff = new Date(entry.expiresAt).getTime() - new Date(entry.cachedAt).getTime();
+    expect(diff).toBe(CACHE_TTL_MS);
+  });
+
+  it('writeCache persiste os itens corretamente em entry.data', () => {
+    writeCache(mockItems);
+    const entry = JSON.parse(localStorage.getItem(CACHE_KEY)!);
+    expect(entry.data).toHaveLength(1);
+    expect(entry.data[0].itemId).toBe('T4_MAIN_SWORD');
+  });
+});
+
+describe('market.cache — AC-2: readCache retorna entrada válida', () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it('readCache retorna null quando localStorage está vazio', () => {
+    expect(readCache()).toBeNull();
+  });
+
+  it('readCache retorna a entrada quando cache existe e não expirou', () => {
+    writeCache(mockItems);
+    const entry = readCache();
+    expect(entry).not.toBeNull();
+    expect(entry!.data).toHaveLength(1);
+    expect(entry!.data[0].itemId).toBe('T4_MAIN_SWORD');
+  });
+
+  it('readCache retorna cachedAt e expiresAt como strings ISO', () => {
+    writeCache(mockItems);
+    const entry = readCache();
+    expect(new Date(entry!.cachedAt).toISOString()).toBe(entry!.cachedAt);
+    expect(new Date(entry!.expiresAt).toISOString()).toBe(entry!.expiresAt);
+  });
+});
+
+describe('market.cache — AC-3: isCacheValid distingue expirado de válido', () => {
+  it('retorna true quando expiresAt está no futuro', () => {
+    const entry = {
+      data: mockItems,
+      cachedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    };
+    expect(isCacheValid(entry)).toBe(true);
+  });
+
+  it('retorna false quando expiresAt está no passado', () => {
+    const entry = {
+      data: mockItems,
+      cachedAt: new Date(Date.now() - CACHE_TTL_MS - 1).toISOString(),
+      expiresAt: new Date(Date.now() - 1).toISOString(),
+    };
+    expect(isCacheValid(entry)).toBe(false);
+  });
+});
+
+describe('market.cache — AC-5: cache corrompido tratado como miss', () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it('readCache retorna null quando localStorage tem JSON inválido', () => {
+    localStorage.setItem(CACHE_KEY, 'NOT_JSON{{{');
+    expect(readCache()).toBeNull();
+  });
+
+  it('readCache retorna null quando faltam campos obrigatórios (sem cachedAt/expiresAt)', () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ data: mockItems }));
+    expect(readCache()).toBeNull();
+  });
+
+  it('readCache retorna null quando data não é array', () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({
+      data: 'invalid',
+      cachedAt: new Date().toISOString(),
+      expiresAt: new Date().toISOString(),
+    }));
+    expect(readCache()).toBeNull();
+  });
+});
+
+// Integração: ApiMarketService usando o cache
+describe('ApiMarketService + cache — AC-2: cache hit não chama fetch', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('getItems() retorna dados do cache sem chamar fetch quando cache é válido', async () => {
+    writeCache(mockItems);
+    vi.stubGlobal('fetch', vi.fn());
+
+    const service = new ApiMarketService();
+    const items = await service.getItems();
+
+    expect(globalThis.fetch as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    expect(items).toHaveLength(1);
+    expect(items[0].itemId).toBe('T4_MAIN_SWORD');
+  });
+});
+
+describe('ApiMarketService + cache — AC-3: cache expirado revalida', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('getItems() chama API e atualiza cache quando cache está expirado', async () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({
+      data: mockItems,
+      cachedAt: new Date(Date.now() - CACHE_TTL_MS - 1000).toISOString(),
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    }));
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue([{
+        item_id: 'T5_MAIN_SWORD',
+        city: 'Bridgewatch',
+        quality: 1,
+        sell_price_min: 90000,
+        sell_price_min_date: '2026-03-16T10:00:00',
+        buy_price_max: 70000,
+        buy_price_max_date: '2026-03-16T09:00:00',
+      }]),
+    }));
+
+    const service = new ApiMarketService();
+    await service.getItems();
+
+    expect(globalThis.fetch).toHaveBeenCalled();
+    const newEntry = readCache();
+    expect(newEntry).not.toBeNull();
+    expect(isCacheValid(newEntry!)).toBe(true);
+  });
+});
+
+describe('ApiMarketService + cache — AC-4: getLastUpdateTime usa cachedAt', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('getLastUpdateTime() retorna cachedAt quando dados são servidos do cache', async () => {
+    const cachedAt = '2026-03-16T08:00:00.000Z';
+    localStorage.setItem(CACHE_KEY, JSON.stringify({
+      data: mockItems,
+      cachedAt,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    }));
+
+    vi.stubGlobal('fetch', vi.fn());
+
+    const service = new ApiMarketService();
+    await service.getItems();
+    const lastUpdate = await service.getLastUpdateTime();
+
+    expect(lastUpdate).toBe(cachedAt);
+  });
+});


### PR DESCRIPTION
## Resumo

- Novo módulo `src/services/market.cache.ts` com `readCache`, `writeCache` e `isCacheValid` (TTL 5 min, schema Zod com validação completa dos campos de `MarketItem`)
- `ApiMarketService.getItems()` verifica o cache antes de qualquer chamada HTTP — em cache hit, retorna imediatamente sem fetch
- `getLastUpdateTime()` reflete `cachedAt` do cache quando os dados são servidos do cache
- Fecha **DEBT-P1-002** — carregamento inicial lento com API real (450 itens × 7 cidades)

## Decisões técnicas

- TTL: 5 minutos (`CACHE_TTL_MS = 300_000`) — balanceia frescor dos dados com redução de chamadas
- Chave localStorage: `albion_market_cache`
- Cache corrompido ou expirado → tratado como miss, busca da API normalmente
- `QuotaExceededError` silenciado — degradação graciosa sem cache quando storage está cheio
- ADR-007 criado documentando trade-offs

## Como testar

- [ ] Abrir o dashboard com `VITE_USE_REAL_API=true` — primeiro carregamento busca da API
- [ ] Recarregar a página dentro de 5 min — deve carregar instantaneamente (sem chamadas HTTP à API de preços)
- [ ] Aguardar 5 min e recarregar — deve buscar da API novamente e atualizar o cache
- [ ] `npm run test` — 102/102 testes passando

## Riscos residuais

- Dados exibidos podem ter até 5 min de atraso em relação ao mercado real (aceitável para uso analítico)
- Estado `cachedLastUpdate` é por instância; em cenário multi-instância (improvável) pode divergir do cache real

🤖 Generated with [Claude Code](https://claude.com/claude-code)