### PR TITLE
chore(logs): consolidar logs e memória pós-sessão typescript-strict-mode-pages

### DIFF
--- a/ERROR_LOG.md
+++ b/ERROR_LOG.md
@@ -114,3 +114,13 @@
 - 106/106 testes passando (102 anteriores + 4 novos)
 - TypeScript compila sem erros com 4 flags adicionais ativadas
 - **Status**: SEM ERROS
+
+---
+
+### [2026-03-17] feat/typescript-strict-mode-pages — sem erros
+
+- Ciclo completo executado: spec-editor → spec-validator → test-red → green-refactor → code-review → quality-gate → report-writer → branch-sync-guard → feature-scope-guard → enforce-workflow → git-flow-manager
+- PR #20 aberto (`feat/typescript-strict-mode-pages` → `main`)
+- 112/112 testes passando (106 anteriores + 6 novos: AC-1 compilação limpa + AC-2 ×5 arquivos)
+- `src/pages/` confirmada type-safe sem supressões com todas as flags vigentes
+- **Status**: SEM ERROS

--- a/PENDING_LOG.md
+++ b/PENDING_LOG.md
@@ -14,6 +14,7 @@
 - **TypeScript strict mode iteração 1** (2026-03-16): `feat/typescript-strict-mode` — PR aceito em `main`; `noImplicitAny: true` + `strictNullChecks: true` ativados em `tsconfig.app.json` e `tsconfig.json`; codebase já era type-safe, sem supressões; 85/85 testes; ADR-006 criado. Fecha DEBT-P0.
 - **Cache com TTL em localStorage** (2026-03-16): `feat/cache-ttl-localstorage` — PR #17 aceito em `main`; `src/services/market.cache.ts` com `readCache`, `writeCache`, `isCacheValid`; TTL 5 min; schema Zod valida campos completos de `MarketItem`; `ApiMarketService.getItems()` verifica cache antes de fetch; `getLastUpdateTime()` reflete `cachedAt`; 102/102 testes; ADR-007 criado. Fecha DEBT-P1-002.
 - **TypeScript strict mode iteração 2 (hooks)** (2026-03-17): `feat/typescript-strict-mode-hooks` — PR #18 aceito em `main`; 4 flags adicionais ativadas (`strictFunctionTypes`, `strictBindCallApply`, `strictPropertyInitialization`, `useUnknownInCatchVariables`); 106/106 testes; codebase continua type-safe sem supressões. Próxima iteração: `src/pages/`.
+- **TypeScript strict mode iteração 3 (pages)** (2026-03-17): `feat/typescript-strict-mode-pages` — PR #20 aberto; 6 testes adicionados em `tsconfig.strict.test.ts` cobrindo AC-1 (compilação limpa de `src/pages/`) e AC-2 (ausência de `@ts-ignore`/`@ts-expect-error` nos 5 arquivos de página); 112/112 testes. Próxima iteração: `src/components/`.
 
 ## Pendências
 
@@ -25,6 +26,6 @@
 
 ## Pontos de atenção
 
-- **TypeScript strict mode iteração 2**: avaliar `src/hooks/` com `noImplicitAny` + `strictNullChecks` já ativos (ver ADR-006).
+- **TypeScript strict mode iteração 4**: auditar `src/components/` (exceto `src/components/ui/`) com as flags vigentes — próximo passo do ADR-006.
 - **Enchanted items** (`.@1/.@2/.@3`): avaliar adição ao catálogo — DEBT-P2 em aberto.
 - **Filtros de UI**: revisar se há gaps de UX remanescentes além de Tier e Cidade no PriceTable.

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -5,8 +5,8 @@
 ## Current project state
 
 **Plataforma:** Dashboard web React + TypeScript para análise de preços do mercado do Albion Online
-**Status:** Baseline estável — PR #18 `feat/typescript-strict-mode-hooks` mergeado; 106/106 testes passando; lint e build limpos
-**Branch ativa:** main | Último PR: `feat/typescript-strict-mode-hooks` (#18) — strict mode iteração 2 completa
+**Status:** Baseline estável — PR #20 `feat/typescript-strict-mode-pages` aberto; 112/112 testes passando; lint e build limpos
+**Branch ativa:** main | Último PR: `feat/typescript-strict-mode-pages` (#20) — strict mode iteração 3 completa
 
 ---
 
@@ -30,19 +30,19 @@
 | TypeScript strict mode iteração 1 | ✅ Fixo | `noImplicitAny: true` + `strictNullChecks: true` em `tsconfig.app.json` e `tsconfig.json`; ADR-006 criado; sem supressões necessárias |
 | Cache de dados de mercado com TTL | ✅ Fixo | `src/services/market.cache.ts`; TTL 5 min (`CACHE_TTL_MS=300_000`); chave `albion_market_cache`; schema Zod valida campos completos de `MarketItem`; `writeCache` silencia `QuotaExceededError`; ADR-007 criado |
 | TypeScript strict mode iteração 2 | ✅ Fixo | 4 flags adicionais ativadas em `tsconfig.app.json`: `strictFunctionTypes`, `strictBindCallApply`, `strictPropertyInitialization`, `useUnknownInCatchVariables`; codebase continua type-safe sem supressões; 106/106 testes |
+| TypeScript strict mode iteração 3 | ✅ Fixo | `src/pages/` auditada: 5 arquivos compilam sem erros e sem `@ts-ignore`/`@ts-expect-error`; 6 testes adicionados em `tsconfig.strict.test.ts`; PR #20 aberto; 112/112 testes |
 
 ---
 
 ## Active fronts
 
-- Nenhuma frente ativa no momento. Baseline limpa, sem feature em andamento.
+- `feat/typescript-strict-mode-pages` — PR #20 aberto, aguardando merge. Iteração 3 concluída.
 
 ---
 
 ## Open decisions
 
-- TypeScript strict mode iteração 3: avaliar `src/pages/` com flags adicionais já ativas
-- TypeScript strict mode iteração 4: avaliar `src/components/` (exceto `src/components/ui/`)
+- TypeScript strict mode iteração 4: auditar `src/components/` (exceto `src/components/ui/`) com flags vigentes
 - Enchanted items (`.@1`, `.@2`, `.@3`): avaliar adição ao catálogo em feature futura
 - Filtros de UI adicionais: revisar gaps de UX remanescentes no PriceTable além de Tier e Cidade
 
@@ -67,8 +67,8 @@
 
 ## Next recommended steps
 
-1. **TypeScript strict mode iteração 3** — avaliar `src/pages/` com flags adicionais já ativas (ADR-006)
-2. **TypeScript strict mode iteração 4** — avaliar `src/components/` (exceto `src/components/ui/`)
+1. **Merge PR #20** — `feat/typescript-strict-mode-pages` aguardando aprovação
+2. **TypeScript strict mode iteração 4** — auditar `src/components/` (exceto `src/components/ui/`) com flags já ativas (ADR-006)
 3. **Enchanted items** — avaliar adição de variantes `.@1/.@2/.@3` ao catálogo (DEBT-P2)
 4. **Filtros de UI** — revisar gaps de UX no PriceTable (pendência aberta)
 
@@ -78,17 +78,16 @@
 
 **Sessão:** 2026-03-17
 **Trabalho realizado:**
-- `feat/typescript-strict-mode-hooks` completo do plano ao PR #18 mergeado
-  - `tsconfig.app.json`: 4 flags adicionais ativadas (`strictFunctionTypes`, `strictBindCallApply`, `strictPropertyInitialization`, `useUnknownInCatchVariables`)
-  - `src/test/tsconfig.strict.test.ts`: 4 testes novos cobrindo AC-1 a AC-4
-  - Sem ajustes necessários nos hooks — codebase já era type-safe
-  - 106/106 testes passando (102 anteriores + 4 novos)
-  - Lint 0 erros; build OK; TypeScript compila sem erros
-  - PR #18 mergeado em `main`
+- `feat/typescript-strict-mode-pages` (iteração 3) — ciclo completo do plano ao PR #20
+  - `src/test/tsconfig.strict.test.ts`: 6 testes novos cobrindo AC-1 (compilação limpa via `tsc --noEmit`) e AC-2 (ausência de supressões nos 5 arquivos de página)
+  - `src/pages/` confirmada type-safe nativamente — sem supressões necessárias
+  - 112/112 testes passando (106 anteriores + 6 novos)
+  - Lint 0 erros; build OK; PR #20 aberto
+- Logs consolidados: `ERROR_LOG.md`, `PENDING_LOG.md` e `memory/MEMORY.md` atualizados
 
-**Estado ao encerrar:** Baseline limpa. 106/106 testes. Lint e build OK. Sem feature ativa.
+**Estado ao encerrar:** PR #20 aberto. 112/112 testes. Lint e build OK. Iteração 3 concluída.
 
 **Retomar por:**
 ```
-session-open → implement-feature typescript-strict-mode-pages
+session-open → implement-feature typescript-strict-mode-components
 ```


### PR DESCRIPTION
## Resumo

Atualização dos arquivos de governança para refletir a sessão de trabalho que
concluiu a iteração 3 do TypeScript strict mode (`src/pages/`).

## Arquivos modificados

| Arquivo | Mudanças |
|---------|----------|
| `ERROR_LOG.md` | +Entrada da iteração 3 (PR #20) com status SEM ERROS |
| `PENDING_LOG.md` | Fechada iteração 2 (hooks), registrada iteração 3 (pages), atualizado pontos de atenção para iteração 4 |
| `memory/MEMORY.md` | Estado: 112/112 testes, active fronts (PR #20), next steps (merge + iteração 4), handoff summary |

## Verificação

```bash
git diff --stat
# Esperado: 3 files changed, ~30 linhas
```

## Riscos

Nenhum — apenas atualização documental de estado.