### PR TITLE
feat(filters): persist PriceTable filters in localStorage

### DIFF
--- a/features/persist-price-filters/REPORT.md
+++ b/features/persist-price-filters/REPORT.md
@@ -1,0 +1,75 @@
+# REPORT — Persist Price Filters
+
+**Feature:** `persist-price-filters`  
+**Branch:** `feat/persist-price-filters`  
+**Data:** 2026-03-19  
+**Status:** `READY_FOR_COMMIT`
+
+---
+
+## Objetivo
+
+Implementar persistência dos filtros do PriceTable via localStorage, completando o AC-5 do SPEC `enhanced-ui-filters` (PR #25). Filtros aplicados agora sobrevivem à navegação entre páginas.
+
+## Escopo Alterado
+
+| Arquivo                                    | Tipo       | Descrição                                                                                 |
+| ------------------------------------------ | ---------- | ----------------------------------------------------------------------------------------- |
+| `src/services/filter.storage.ts`           | Novo       | Serviço de persistência com validação defensiva                                           |
+| `src/components/dashboard/PriceTable.tsx`  | Modificado | Integração com filterStorage; useEffect para persistir; flag shouldPersist para Clear All |
+| `src/test/PriceTable.persistence.test.tsx` | Novo       | 10 testes cobrindo AC-1 a AC-4                                                            |
+| `src/test/PriceTable.test.tsx`             | Modificado | Fix regressão: `beforeEach(() => localStorage.clear())`                                   |
+| `features/persist-price-filters/SPEC.md`   | Novo       | Especificação da feature                                                                  |
+
+## Validações Executuadas
+
+| Gate                | Resultado              | Evidência                                                  |
+| ------------------- | ---------------------- | ---------------------------------------------------------- |
+| **Lint**            | ✅                     | 7 warnings (shadcn/ui, esperados)                          |
+| **Build**           | ✅                     | 1770 módulos, bundle ~400KB                                |
+| **TypeScript**      | ✅                     | `strict: true`, sem erros                                  |
+| **Unit Tests**      | ✅                     | 215/215 passando (10 novos)                                |
+| **Quality Gate**    | `QUALITY_PASS`         | Todos os ACs cobertos                                      |
+| **Code Review**     | `REVIEW_OK_WITH_NOTES` | Sem bloqueadores; nota: extrair hook em futura refatoração |
+| **Security Review** | `SECURITY_PASS`        | Validação defensiva adequada; React escapa output          |
+
+## Critérios de Aceitação
+
+| ID   | Critério                       | Status | Evidência                                       |
+| ---- | ------------------------------ | ------ | ----------------------------------------------- |
+| AC-1 | Salvar filtros no localStorage | ✅     | Testes: salvar categoria, cidade, preço         |
+| AC-2 | Restaurar filtros ao retornar  | ✅     | Testes: restaurar estado, aplicar à tabela      |
+| AC-3 | Clear All remove persistência  | ✅     | Testes: remover storage, resetar UI             |
+| AC-4 | Validação defensiva            | ✅     | Testes: ignorar JSON inválido, tipos incorretos |
+
+## Riscos Residuais
+
+| Risco                                | Severidade | Mitigação                                                     |
+| ------------------------------------ | ---------- | ------------------------------------------------------------- |
+| Dados corrompidos de versões futuras | Baixa      | `isValidFilterState()` valida schema; campos extras ignorados |
+| XSS via localStorage                 | Baixa      | React escapa automaticamente; sem `dangerouslySetInnerHTML`   |
+| Performance (sync IO)                | Baixa      | localStorage é síncrono mas volume de dados é pequeno (<1KB)  |
+
+## Follow-ups
+
+1. **Refatoração**: Extrair lógica de persistência para hook `usePersistentFilters()` quando houver segundo uso (DRY).
+2. **UX**: Considerar indicador visual de "filtros restaurados" na primeira visita (baixa prioridade).
+3. **Testes E2E**: Adicionar cenário de persistência entre navegação em `alerts-manager-e2e` (opcional).
+
+## Decisões Técnicas
+
+- **Chave localStorage**: `albion_price_filters` (consistente com `albion_alerts` e `albion_market_cache`)
+- **Estratégia de persistência**: Salvar apenas filtros (não search, sort, paginação)
+- **Clear All**: Remove completamente do storage (não apenas reseta para defaults)
+- **shouldPersist flag**: Workaround para evitar race condition entre setState e useEffect no Clear All
+
+## Notas para Revisores
+
+- Implementação segue padrão de `alert.storage.ts` (ADR-004)
+- TypeScript strict mode sem supressões
+- Não há alterações em CI/CD, Docker ou workflows
+- README.md modificado fora desta feature (atualização de documentação geral)
+
+---
+
+**Status Final:** `READY_FOR_COMMIT`

--- a/features/persist-price-filters/SPEC.md
+++ b/features/persist-price-filters/SPEC.md
@@ -1,0 +1,88 @@
+# SPEC — Persist Price Filters
+
+**Status:** Draft
+**Data:** 2026-03-19
+**Autor:** AI Assistant
+**Branch sugerida:** `feat/persist-price-filters`
+
+---
+
+## Contexto e Motivação
+
+O PriceTable já possui filtros avançados implementados no PR #25 (enhanced-ui-filters), incluindo filtros por faixa de preço, spread, categoria, cidade, tier, qualidade e encantamento. No entanto, quando o usuário navega para outra página e retorna, todos os filtros são perdidos e resetados para o estado padrão. Isso prejudica a experiência de usuários que desejam manter seu contexto de análise durante a navegação.
+
+Esta feature implementa o AC-5 do SPEC `enhanced-ui-filters`, adicionando persistência dos filtros do PriceTable via localStorage.
+
+## Problema a Resolver
+
+- Filtros aplicados no PriceTable são perdidos ao navegar para outra rota
+- Usuários precisam reconfigurar filtros toda vez que retornam à página
+- Não há distinção entre "limpar filtros intencionalmente" vs "navegar e voltar"
+
+## Fora do Escopo
+
+- Persistência de ordenação (sortField, sortDirection)
+- Persistência de paginação (currentPage)
+- Sincronização entre abas/janelas (BroadcastChannel)
+- Expiração/TTL dos filtros (será tratado em futura iteração se necessário)
+
+## Critérios de Aceitação
+
+### AC-1: Salvar filtros no localStorage
+
+**Given** que o usuário está no PriceTable
+**And** aplica um ou mais filtros (categoria, cidade, tier, qualidade, encantamento, preço mín/máx, spread mín/máx)
+**When** os filtros são alterados
+**Then** o estado dos filtros deve ser persistido em `localStorage` com chave `albion_price_filters`
+
+### AC-2: Restaurar filtros ao retornar
+
+**Given** que o usuário aplicou filtros previamente
+**And** os filtros estão salvos no localStorage
+**When** o usuário retorna à página do PriceTable
+**Then** os filtros devem ser restaurados automaticamente do localStorage
+**And** a tabela deve refletir os filtros aplicados
+
+### AC-3: Limpar filtros remove persistência
+
+**Given** que filtros estão salvos no localStorage
+**When** o usuário clica em "Clear All" (botão de limpar filtros)
+**Then** os filtros devem ser resetados para o padrão
+**And** a entrada no localStorage deve ser removida (ou definida como estado vazio)
+
+### AC-4: Validação defensiva de dados persistidos
+
+**Given** que existe dados no localStorage em `albion_price_filters`
+**When** o usuário retorna à página
+**Then** o sistema deve validar o schema dos dados antes de aplicar
+**And** se os dados forem inválidos/corrompidos, devem ser ignorados e removidos
+
+## Dependências
+
+- `feat/enhanced-ui-filters` (PR #25) — já mergeada em main
+- `feat/typescript-strict-mode-components` (PR #22) — já mergeada
+- `src/services/alert.storage.ts` — serviço similar de persistência para referência
+
+## Riscos e Incertezas
+
+- Dados corrompidos no localStorage podem quebrar a UI
+- Versões futuras com novos filtros podem conflitar com dados antigos persistidos
+- Performance: leitura/escrita síncrona no localStorage pode bloquear brevemente
+
+## Referências
+
+- SPEC `enhanced-ui-filters` AC-5
+- ADR-004 (padrão de persistência em localStorage)
+- `src/services/alert.storage.ts` (implementação similar)
+- `memory/MEMORY.md` — pendência de persistência de filtros
+
+---
+
+## Checklist de Validação
+
+- [ ] Filtros salvos ao alterar qualquer filtro
+- [ ] Filtros restaurados ao carregar a página
+- [ ] Clear All remove persistência
+- [ ] Dados inválidos são tratados sem crash
+- [ ] TypeScript strict mode sem supressões
+- [ ] Testes cobrem casos feliz, borda e erro

--- a/src/components/dashboard/PriceTable.tsx
+++ b/src/components/dashboard/PriceTable.tsx
@@ -1,104 +1,181 @@
-import { useState, useMemo } from 'react';
-import { 
-  ArrowUpDown, 
-  ArrowUp, 
-  ArrowDown, 
-  Search, 
+import { useState, useMemo, useEffect, useRef } from "react";
+import {
+  ArrowUpDown,
+  ArrowUp,
+  ArrowDown,
+  Search,
   Filter,
   ChevronLeft,
-  ChevronRight
-} from 'lucide-react';
-import type { MarketItem } from '@/data/types';
-import { cities, tiers, qualities, ITEM_CATALOG, ENCHANTMENT_LEVELS } from '@/data/constants';
-import type { CatalogCategoryKey } from '@/data/constants';
-import { Sparkline } from '@/components/ui/sparkline';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+  ChevronRight,
+} from "lucide-react";
+import type { MarketItem } from "@/data/types";
+import {
+  cities,
+  tiers,
+  qualities,
+  ITEM_CATALOG,
+  ENCHANTMENT_LEVELS,
+} from "@/data/constants";
+import type { CatalogCategoryKey } from "@/data/constants";
+import { Sparkline } from "@/components/ui/sparkline";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select';
-import { cn } from '@/lib/utils';
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { filterStorage } from "@/services/filter.storage";
 
 interface PriceTableProps {
   items: MarketItem[];
   className?: string;
 }
 
-type SortField = 'itemName' | 'city' | 'sellPrice' | 'buyPrice' | 'spread' | 'spreadPercent' | 'timestamp';
-type SortDirection = 'asc' | 'desc';
+type SortField =
+  | "itemName"
+  | "city"
+  | "sellPrice"
+  | "buyPrice"
+  | "spread"
+  | "spreadPercent"
+  | "timestamp";
+type SortDirection = "asc" | "desc";
 
 export function PriceTable({ items, className }: PriceTableProps) {
-  const [search, setSearch] = useState('');
-  const [categoryFilter, setCategoryFilter] = useState<CatalogCategoryKey | 'all'>('all');
-  const [cityFilter, setCityFilter] = useState<string>('all');
-  const [tierFilter, setTierFilter] = useState<string>('all');
-  const [qualityFilter, setQualityFilter] = useState<string>('all');
-  const [enchantFilter, setEnchantFilter] = useState<string>('all');
-  const [minPrice, setMinPrice] = useState<string>('');
-  const [maxPrice, setMaxPrice] = useState<string>('');
-  const [minSpread, setMinSpread] = useState<string>('');
-  const [maxSpread, setMaxSpread] = useState<string>('');
-  const [sortField, setSortField] = useState<SortField>('spreadPercent');
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  // Load persisted filters on mount
+  const persistedFilters = filterStorage.getFilters();
+
+  const [search, setSearch] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState<
+    CatalogCategoryKey | "all"
+  >((persistedFilters.categoryFilter as CatalogCategoryKey | "all") || "all");
+  const [cityFilter, setCityFilter] = useState<string>(
+    persistedFilters.cityFilter || "all",
+  );
+  const [tierFilter, setTierFilter] = useState<string>(
+    persistedFilters.tierFilter || "all",
+  );
+  const [qualityFilter, setQualityFilter] = useState<string>(
+    persistedFilters.qualityFilter || "all",
+  );
+  const [enchantFilter, setEnchantFilter] = useState<string>(
+    persistedFilters.enchantFilter || "all",
+  );
+  const [minPrice, setMinPrice] = useState<string>(
+    persistedFilters.minPrice || "",
+  );
+  const [maxPrice, setMaxPrice] = useState<string>(
+    persistedFilters.maxPrice || "",
+  );
+  const [minSpread, setMinSpread] = useState<string>(
+    persistedFilters.minSpread || "",
+  );
+  const [maxSpread, setMaxSpread] = useState<string>(
+    persistedFilters.maxSpread || "",
+  );
+  const [sortField, setSortField] = useState<SortField>("spreadPercent");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
   const [currentPage, setCurrentPage] = useState(1);
+  const [shouldPersist, setShouldPersist] = useState(true);
   const itemsPerPage = 10;
+
+  // Persist filters when they change (skip on initial mount)
+  const isInitialMount = useRef(true);
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+    if (!shouldPersist) {
+      // Clear was clicked, don't save
+      return;
+    }
+    filterStorage.saveFilters({
+      categoryFilter,
+      cityFilter,
+      tierFilter,
+      qualityFilter,
+      enchantFilter,
+      minPrice,
+      maxPrice,
+      minSpread,
+      maxSpread,
+    });
+  }, [
+    categoryFilter,
+    cityFilter,
+    tierFilter,
+    qualityFilter,
+    enchantFilter,
+    minPrice,
+    maxPrice,
+    minSpread,
+    maxSpread,
+    shouldPersist,
+  ]);
 
   const filteredAndSortedItems = useMemo(() => {
     let result = [...items];
 
     // Apply filters
-    if (categoryFilter !== 'all') {
+    if (categoryFilter !== "all") {
       const ids = new Set(ITEM_CATALOG[categoryFilter].ids);
-      result = result.filter(item => ids.has(item.itemId));
+      result = result.filter((item) => ids.has(item.itemId));
     }
 
     if (search) {
       const searchLower = search.toLowerCase();
       result = result.filter(
-        item => 
+        (item) =>
           item.itemName.toLowerCase().includes(searchLower) ||
-          item.itemId.toLowerCase().includes(searchLower)
+          item.itemId.toLowerCase().includes(searchLower),
       );
     }
 
-    if (cityFilter !== 'all') {
-      result = result.filter(item => item.city === cityFilter);
+    if (cityFilter !== "all") {
+      result = result.filter((item) => item.city === cityFilter);
     }
 
-    if (tierFilter !== 'all') {
-      result = result.filter(item => item.tier === tierFilter);
+    if (tierFilter !== "all") {
+      result = result.filter((item) => item.tier === tierFilter);
     }
 
-    if (qualityFilter !== 'all') {
-      result = result.filter(item => item.quality === qualityFilter);
+    if (qualityFilter !== "all") {
+      result = result.filter((item) => item.quality === qualityFilter);
     }
 
-    if (enchantFilter !== 'all') {
+    if (enchantFilter !== "all") {
       const enchantLevel = parseInt(enchantFilter);
-      result = result.filter(item => {
+      result = result.filter((item) => {
         const itemEnchantLevel = item.itemId.match(/@([0-3])$/)?.[1];
-        return itemEnchantLevel ? parseInt(itemEnchantLevel) === enchantLevel : enchantLevel === 0;
+        return itemEnchantLevel
+          ? parseInt(itemEnchantLevel) === enchantLevel
+          : enchantLevel === 0;
       });
     }
 
     if (minPrice) {
-      result = result.filter(item => item.sellPrice >= parseInt(minPrice));
+      result = result.filter((item) => item.sellPrice >= parseInt(minPrice));
     }
 
     if (maxPrice) {
-      result = result.filter(item => item.sellPrice <= parseInt(maxPrice));
+      result = result.filter((item) => item.sellPrice <= parseInt(maxPrice));
     }
 
     if (minSpread) {
-      result = result.filter(item => item.spreadPercent >= parseInt(minSpread));
+      result = result.filter(
+        (item) => item.spreadPercent >= parseInt(minSpread),
+      );
     }
 
     if (maxSpread) {
-      result = result.filter(item => item.spreadPercent <= parseInt(maxSpread));
+      result = result.filter(
+        (item) => item.spreadPercent <= parseInt(maxSpread),
+      );
     }
 
     // Apply sorting
@@ -106,72 +183,91 @@ export function PriceTable({ items, className }: PriceTableProps) {
       const aVal = a[sortField];
       const bVal = b[sortField];
 
-      if (typeof aVal === 'string' && typeof bVal === 'string') {
-        return sortDirection === 'asc' 
+      if (typeof aVal === "string" && typeof bVal === "string") {
+        return sortDirection === "asc"
           ? aVal.localeCompare(bVal)
           : bVal.localeCompare(aVal);
       }
 
-      if (typeof aVal === 'number' && typeof bVal === 'number') {
-        return sortDirection === 'asc' ? aVal - bVal : bVal - aVal;
+      if (typeof aVal === "number" && typeof bVal === "number") {
+        return sortDirection === "asc" ? aVal - bVal : bVal - aVal;
       }
 
       return 0;
     });
 
     return result;
-  }, [items, search, categoryFilter, cityFilter, tierFilter, qualityFilter, enchantFilter, minPrice, maxPrice, minSpread, maxSpread, sortField, sortDirection]);
+  }, [
+    items,
+    search,
+    categoryFilter,
+    cityFilter,
+    tierFilter,
+    qualityFilter,
+    enchantFilter,
+    minPrice,
+    maxPrice,
+    minSpread,
+    maxSpread,
+    sortField,
+    sortDirection,
+  ]);
 
   const totalPages = Math.ceil(filteredAndSortedItems.length / itemsPerPage);
   const paginatedItems = filteredAndSortedItems.slice(
     (currentPage - 1) * itemsPerPage,
-    currentPage * itemsPerPage
+    currentPage * itemsPerPage,
   );
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
-      setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc');
+      setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
     } else {
       setSortField(field);
-      setSortDirection('desc');
+      setSortDirection("desc");
     }
   };
 
   const formatPrice = (price: number) => {
-    return new Intl.NumberFormat('en-US').format(price);
+    return new Intl.NumberFormat("en-US").format(price);
   };
 
   const formatTime = (timestamp: string) => {
     const date = new Date(timestamp);
     const now = new Date();
     const diffMinutes = Math.floor((now.getTime() - date.getTime()) / 60000);
-    
-    if (diffMinutes < 1) return 'Just now';
+
+    if (diffMinutes < 1) return "Just now";
     if (diffMinutes < 60) return `${diffMinutes}m ago`;
     return `${Math.floor(diffMinutes / 60)}h ago`;
   };
 
   const SortIcon = ({ field }: { field: SortField }) => {
-    if (sortField !== field) return <ArrowUpDown className="h-3 w-3 opacity-50" />;
-    return sortDirection === 'asc'
-      ? <ArrowUp className="h-3 w-3 text-primary" />
-      : <ArrowDown className="h-3 w-3 text-primary" />;
+    if (sortField !== field)
+      return <ArrowUpDown className="h-3 w-3 opacity-50" />;
+    return sortDirection === "asc" ? (
+      <ArrowUp className="h-3 w-3 text-primary" />
+    ) : (
+      <ArrowDown className="h-3 w-3 text-primary" />
+    );
   };
 
   const clearAllFilters = () => {
-    setCategoryFilter('all');
-    setCityFilter('all');
-    setTierFilter('all');
-    setQualityFilter('all');
-    setEnchantFilter('all');
-    setMinPrice('');
-    setMaxPrice('');
-    setMinSpread('');
-    setMaxSpread('');
+    setShouldPersist(false);
+    setCategoryFilter("all");
+    setCityFilter("all");
+    setTierFilter("all");
+    setQualityFilter("all");
+    setEnchantFilter("all");
+    setMinPrice("");
+    setMaxPrice("");
+    setMinSpread("");
+    setMaxSpread("");
+    filterStorage.clearFilters();
   };
 
   return (
-    <div className={cn('glass-card overflow-hidden', className)}>
+    <div className={cn("glass-card overflow-hidden", className)}>
       {/* Filters Bar */}
       <div className="p-4 border-b border-border/50">
         <div className="flex flex-col lg:flex-row gap-3">
@@ -184,29 +280,49 @@ export function PriceTable({ items, className }: PriceTableProps) {
               className="pl-9 bg-muted/50 border-border/50"
             />
           </div>
-          
+
           <div className="flex flex-wrap gap-2">
-            <Select value={categoryFilter} onValueChange={(v) => setCategoryFilter(v as CatalogCategoryKey | 'all')}>
-              <SelectTrigger className="w-[150px] bg-muted/50 border-border/50" aria-label="Category">
+            <Select
+              value={categoryFilter}
+              onValueChange={(v) =>
+                setCategoryFilter(v as CatalogCategoryKey | "all")
+              }
+            >
+              <SelectTrigger
+                className="w-[150px] bg-muted/50 border-border/50"
+                aria-label="Category"
+              >
                 <SelectValue placeholder="Category" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All Categories</SelectItem>
-                {(Object.entries(ITEM_CATALOG) as [CatalogCategoryKey, { label: string }][]).map(([key, cat]) => (
-                  <SelectItem key={key} value={key}>{cat.label}</SelectItem>
+                {(
+                  Object.entries(ITEM_CATALOG) as [
+                    CatalogCategoryKey,
+                    { label: string },
+                  ][]
+                ).map(([key, cat]) => (
+                  <SelectItem key={key} value={key}>
+                    {cat.label}
+                  </SelectItem>
                 ))}
               </SelectContent>
             </Select>
 
             <Select value={cityFilter} onValueChange={setCityFilter}>
-              <SelectTrigger className="w-[140px] bg-muted/50 border-border/50">
+              <SelectTrigger
+                className="w-[140px] bg-muted/50 border-border/50"
+                aria-label="City"
+              >
                 <Filter className="h-3 w-3 mr-2" />
                 <SelectValue placeholder="City" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All Cities</SelectItem>
-                {cities.map(city => (
-                  <SelectItem key={city} value={city}>{city}</SelectItem>
+                {cities.map((city) => (
+                  <SelectItem key={city} value={city}>
+                    {city}
+                  </SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -217,8 +333,10 @@ export function PriceTable({ items, className }: PriceTableProps) {
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All Tiers</SelectItem>
-                {tiers.map(tier => (
-                  <SelectItem key={tier} value={tier}>{tier}</SelectItem>
+                {tiers.map((tier) => (
+                  <SelectItem key={tier} value={tier}>
+                    {tier}
+                  </SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -229,8 +347,10 @@ export function PriceTable({ items, className }: PriceTableProps) {
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All Qualities</SelectItem>
-                {qualities.map(quality => (
-                  <SelectItem key={quality} value={quality}>{quality}</SelectItem>
+                {qualities.map((quality) => (
+                  <SelectItem key={quality} value={quality}>
+                    {quality}
+                  </SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -241,9 +361,9 @@ export function PriceTable({ items, className }: PriceTableProps) {
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All Levels</SelectItem>
-                {ENCHANTMENT_LEVELS.map(level => (
+                {ENCHANTMENT_LEVELS.map((level) => (
                   <SelectItem key={level} value={String(level)}>
-                    {level === 0 ? 'No Enchant' : `Level ${level}`}
+                    {level === 0 ? "No Enchant" : `Level ${level}`}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -283,9 +403,15 @@ export function PriceTable({ items, className }: PriceTableProps) {
               />
             </div>
 
-            {(categoryFilter !== 'all' || cityFilter !== 'all' || tierFilter !== 'all' || 
-              qualityFilter !== 'all' || enchantFilter !== 'all' || minPrice || maxPrice || 
-              minSpread || maxSpread) && (
+            {(categoryFilter !== "all" ||
+              cityFilter !== "all" ||
+              tierFilter !== "all" ||
+              qualityFilter !== "all" ||
+              enchantFilter !== "all" ||
+              minPrice ||
+              maxPrice ||
+              minSpread ||
+              maxSpread) && (
               <Button
                 variant="outline"
                 size="sm"
@@ -299,14 +425,31 @@ export function PriceTable({ items, className }: PriceTableProps) {
         </div>
 
         {/* Active filters indicator */}
-        {(categoryFilter !== 'all' || cityFilter !== 'all' || tierFilter !== 'all' ||
-          qualityFilter !== 'all' || enchantFilter !== 'all' || minPrice || maxPrice ||
-          minSpread || maxSpread) && (
+        {(categoryFilter !== "all" ||
+          cityFilter !== "all" ||
+          tierFilter !== "all" ||
+          qualityFilter !== "all" ||
+          enchantFilter !== "all" ||
+          minPrice ||
+          maxPrice ||
+          minSpread ||
+          maxSpread) && (
           <div className="mt-3 flex items-center gap-2 text-sm text-muted-foreground">
             <span className="font-medium">
-              {[categoryFilter !== 'all', cityFilter !== 'all', tierFilter !== 'all',
-                qualityFilter !== 'all', enchantFilter !== 'all', minPrice, maxPrice,
-                minSpread, maxSpread].filter(Boolean).length} filter active
+              {
+                [
+                  categoryFilter !== "all",
+                  cityFilter !== "all",
+                  tierFilter !== "all",
+                  qualityFilter !== "all",
+                  enchantFilter !== "all",
+                  minPrice,
+                  maxPrice,
+                  minSpread,
+                  maxSpread,
+                ].filter(Boolean).length
+              }{" "}
+              filter active
             </span>
           </div>
         )}
@@ -318,51 +461,53 @@ export function PriceTable({ items, className }: PriceTableProps) {
           <thead>
             <tr className="border-b border-border/50 bg-muted/30">
               <th className="text-left p-3">
-                <button 
-                  onClick={() => handleSort('itemName')}
+                <button
+                  onClick={() => handleSort("itemName")}
                   className="flex items-center gap-1 text-xs font-semibold text-muted-foreground hover:text-foreground transition-colors"
                 >
                   Item <SortIcon field="itemName" />
                 </button>
               </th>
               <th className="text-left p-3">
-                <button 
-                  onClick={() => handleSort('city')}
+                <button
+                  onClick={() => handleSort("city")}
                   className="flex items-center gap-1 text-xs font-semibold text-muted-foreground hover:text-foreground transition-colors"
                 >
                   City <SortIcon field="city" />
                 </button>
               </th>
               <th className="text-right p-3">
-                <button 
-                  onClick={() => handleSort('sellPrice')}
+                <button
+                  onClick={() => handleSort("sellPrice")}
                   className="flex items-center gap-1 text-xs font-semibold text-muted-foreground hover:text-foreground transition-colors ml-auto"
                 >
                   Sell Price <SortIcon field="sellPrice" />
                 </button>
               </th>
               <th className="text-right p-3">
-                <button 
-                  onClick={() => handleSort('buyPrice')}
+                <button
+                  onClick={() => handleSort("buyPrice")}
                   className="flex items-center gap-1 text-xs font-semibold text-muted-foreground hover:text-foreground transition-colors ml-auto"
                 >
                   Buy Price <SortIcon field="buyPrice" />
                 </button>
               </th>
               <th className="text-right p-3">
-                <button 
-                  onClick={() => handleSort('spreadPercent')}
+                <button
+                  onClick={() => handleSort("spreadPercent")}
                   className="flex items-center gap-1 text-xs font-semibold text-muted-foreground hover:text-foreground transition-colors ml-auto"
                 >
                   Spread <SortIcon field="spreadPercent" />
                 </button>
               </th>
               <th className="text-center p-3 hidden md:table-cell">
-                <span className="text-xs font-semibold text-muted-foreground">Trend</span>
+                <span className="text-xs font-semibold text-muted-foreground">
+                  Trend
+                </span>
               </th>
               <th className="text-right p-3">
-                <button 
-                  onClick={() => handleSort('timestamp')}
+                <button
+                  onClick={() => handleSort("timestamp")}
                   className="flex items-center gap-1 text-xs font-semibold text-muted-foreground hover:text-foreground transition-colors ml-auto"
                 >
                   Updated <SortIcon field="timestamp" />
@@ -373,7 +518,10 @@ export function PriceTable({ items, className }: PriceTableProps) {
           <tbody>
             {paginatedItems.length === 0 ? (
               <tr>
-                <td colSpan={7} className="text-center py-12 text-muted-foreground">
+                <td
+                  colSpan={7}
+                  className="text-center py-12 text-muted-foreground"
+                >
                   <div className="flex flex-col items-center gap-2">
                     <Search className="h-8 w-8 opacity-50" />
                     <p>No items found matching your criteria</p>
@@ -382,39 +530,54 @@ export function PriceTable({ items, className }: PriceTableProps) {
               </tr>
             ) : (
               paginatedItems.map((item, index) => (
-                <tr 
+                <tr
                   key={item.itemId + index}
                   className="border-b border-border/30 hover:bg-muted/30 transition-colors"
                 >
                   <td className="p-3">
                     <div className="flex items-center gap-2">
                       <div>
-                        <p className="font-medium text-sm text-foreground">{item.itemName}</p>
+                        <p className="font-medium text-sm text-foreground">
+                          {item.itemName}
+                        </p>
                         <div className="flex items-center gap-1.5 mt-0.5">
                           <span className="text-xs px-1.5 py-0.5 rounded bg-primary/10 text-primary font-medium">
                             {item.tier}
                           </span>
-                          <span className="text-xs text-muted-foreground">{item.quality}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {item.quality}
+                          </span>
                         </div>
                       </div>
                     </div>
                   </td>
                   <td className="p-3">
-                    <span className="text-sm text-muted-foreground">{item.city}</span>
+                    <span className="text-sm text-muted-foreground">
+                      {item.city}
+                    </span>
                   </td>
                   <td className="p-3 text-right">
-                    <span className="font-mono text-sm text-foreground">{formatPrice(item.sellPrice)}</span>
+                    <span className="font-mono text-sm text-foreground">
+                      {formatPrice(item.sellPrice)}
+                    </span>
                   </td>
                   <td className="p-3 text-right">
-                    <span className="font-mono text-sm text-foreground">{formatPrice(item.buyPrice)}</span>
+                    <span className="font-mono text-sm text-foreground">
+                      {formatPrice(item.buyPrice)}
+                    </span>
                   </td>
                   <td className="p-3 text-right">
                     <div className="flex flex-col items-end">
-                      <span className={cn(
-                        'font-mono text-sm font-semibold',
-                        item.spreadPercent > 20 ? 'text-success' : 
-                        item.spreadPercent > 10 ? 'text-primary' : 'text-muted-foreground'
-                      )}>
+                      <span
+                        className={cn(
+                          "font-mono text-sm font-semibold",
+                          item.spreadPercent > 20
+                            ? "text-success"
+                            : item.spreadPercent > 10
+                              ? "text-primary"
+                              : "text-muted-foreground",
+                        )}
+                      >
                         +{item.spreadPercent.toFixed(1)}%
                       </span>
                       <span className="text-xs text-muted-foreground font-mono">
@@ -428,7 +591,9 @@ export function PriceTable({ items, className }: PriceTableProps) {
                     </div>
                   </td>
                   <td className="p-3 text-right">
-                    <span className="text-xs text-muted-foreground">{formatTime(item.timestamp)}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {formatTime(item.timestamp)}
+                    </span>
                   </td>
                 </tr>
               ))
@@ -441,13 +606,18 @@ export function PriceTable({ items, className }: PriceTableProps) {
       {totalPages > 1 && (
         <div className="p-4 border-t border-border/50 flex items-center justify-between">
           <p className="text-sm text-muted-foreground">
-            Showing {((currentPage - 1) * itemsPerPage) + 1} to {Math.min(currentPage * itemsPerPage, filteredAndSortedItems.length)} of {filteredAndSortedItems.length} items
+            Showing {(currentPage - 1) * itemsPerPage + 1} to{" "}
+            {Math.min(
+              currentPage * itemsPerPage,
+              filteredAndSortedItems.length,
+            )}{" "}
+            of {filteredAndSortedItems.length} items
           </p>
           <div className="flex items-center gap-2">
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
+              onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
               disabled={currentPage === 1}
             >
               <ChevronLeft className="h-4 w-4" />
@@ -464,16 +634,17 @@ export function PriceTable({ items, className }: PriceTableProps) {
                 } else {
                   page = currentPage - 2 + i;
                 }
-                
+
                 return (
                   <Button
                     key={page}
-                    variant={currentPage === page ? 'default' : 'ghost'}
+                    variant={currentPage === page ? "default" : "ghost"}
                     size="sm"
                     onClick={() => setCurrentPage(page)}
                     className={cn(
-                      'w-8 h-8 p-0',
-                      currentPage === page && 'bg-primary text-primary-foreground'
+                      "w-8 h-8 p-0",
+                      currentPage === page &&
+                        "bg-primary text-primary-foreground",
                     )}
                   >
                     {page}
@@ -484,7 +655,9 @@ export function PriceTable({ items, className }: PriceTableProps) {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
+              onClick={() =>
+                setCurrentPage((prev) => Math.min(totalPages, prev + 1))
+              }
               disabled={currentPage === totalPages}
             >
               <ChevronRight className="h-4 w-4" />

--- a/src/services/filter.storage.ts
+++ b/src/services/filter.storage.ts
@@ -1,0 +1,86 @@
+const STORAGE_KEY = "albion_price_filters";
+
+export interface FilterState {
+  categoryFilter?: string;
+  cityFilter?: string;
+  tierFilter?: string;
+  qualityFilter?: string;
+  enchantFilter?: string;
+  minPrice?: string;
+  maxPrice?: string;
+  minSpread?: string;
+  maxSpread?: string;
+}
+
+const defaultState: FilterState = {
+  categoryFilter: "all",
+  cityFilter: "all",
+  tierFilter: "all",
+  qualityFilter: "all",
+  enchantFilter: "all",
+  minPrice: "",
+  maxPrice: "",
+  minSpread: "",
+  maxSpread: "",
+};
+
+function isValidFilterState(state: unknown): state is FilterState {
+  if (typeof state !== "object" || state === null) return false;
+
+  const s = state as Record<string, unknown>;
+
+  // Verifica se todos os valores são strings ou undefined
+  const stringFields = [
+    "categoryFilter",
+    "cityFilter",
+    "tierFilter",
+    "qualityFilter",
+    "enchantFilter",
+    "minPrice",
+    "maxPrice",
+    "minSpread",
+    "maxSpread",
+  ];
+
+  for (const field of stringFields) {
+    const value = s[field];
+    if (value !== undefined && typeof value !== "string") {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export class FilterStorageService {
+  getFilters(): FilterState {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return { ...defaultState };
+
+      const parsed = JSON.parse(raw);
+
+      if (!isValidFilterState(parsed)) {
+        // Dados inválidos - limpa o localStorage
+        localStorage.removeItem(STORAGE_KEY);
+        return { ...defaultState };
+      }
+
+      return { ...defaultState, ...parsed };
+    } catch {
+      // JSON inválido - limpa o localStorage
+      localStorage.removeItem(STORAGE_KEY);
+      return { ...defaultState };
+    }
+  }
+
+  saveFilters(filters: FilterState): void {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(filters));
+  }
+
+  clearFilters(): void {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+export const filterStorage = new FilterStorageService();

--- a/src/test/PriceTable.persistence.test.tsx
+++ b/src/test/PriceTable.persistence.test.tsx
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PriceTable } from "@/components/dashboard/PriceTable";
+import type { MarketItem } from "@/data/types";
+
+const LOCAL_STORAGE_KEY = "albion_price_filters";
+
+const mockItems: MarketItem[] = [
+  {
+    itemId: "T4_MAIN_SWORD",
+    itemName: "Broadsword T4",
+    city: "Caerleon",
+    sellPrice: 50000,
+    buyPrice: 40000,
+    spread: 10000,
+    spreadPercent: 25,
+    timestamp: new Date().toISOString(),
+    tier: "T4",
+    quality: "Normal",
+    priceHistory: [45000, 46000, 47000],
+  },
+  {
+    itemId: "T5_MAIN_AXE",
+    itemName: "Battleaxe T5",
+    city: "Bridgewatch",
+    sellPrice: 80000,
+    buyPrice: 60000,
+    spread: 20000,
+    spreadPercent: 33,
+    timestamp: new Date().toISOString(),
+    tier: "T5",
+    quality: "Normal",
+    priceHistory: [75000, 77000, 80000],
+  },
+  {
+    itemId: "T4_BAG@2",
+    itemName: "Bag T4.2",
+    city: "Martlock",
+    sellPrice: 65000,
+    buyPrice: 50000,
+    spread: 15000,
+    spreadPercent: 30,
+    timestamp: new Date().toISOString(),
+    tier: "T4",
+    quality: "Outstanding",
+    priceHistory: [62000, 63000, 65000],
+  },
+];
+
+describe("PriceTable — persistência de filtros (AC-5)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe("AC-1: Salvar filtros no localStorage", () => {
+    it("deve salvar filtros ao alterar categoria", async () => {
+      const user = userEvent.setup();
+      render(<PriceTable items={mockItems} />);
+
+      const categorySelect = screen.getByRole("combobox", {
+        name: /category/i,
+      });
+      await user.click(categorySelect);
+      await user.click(await screen.findByRole("option", { name: /swords/i }));
+
+      const saved = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || "{}");
+      expect(saved.categoryFilter).toBe("swords");
+    });
+
+    it("deve salvar filtros ao alterar cidade", async () => {
+      const user = userEvent.setup();
+      render(<PriceTable items={mockItems} />);
+
+      const citySelect = screen.getByRole("combobox", { name: /city/i });
+      await user.click(citySelect);
+      await user.click(
+        await screen.findByRole("option", { name: /caerleon/i }),
+      );
+
+      const saved = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || "{}");
+      expect(saved.cityFilter).toBe("Caerleon");
+    });
+
+    it("deve salvar filtros de preço ao digitar", async () => {
+      const user = userEvent.setup();
+      render(<PriceTable items={mockItems} />);
+
+      const minPriceInput = screen.getByPlaceholderText(/min price/i);
+      await user.type(minPriceInput, "60000");
+
+      const saved = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || "{}");
+      expect(saved.minPrice).toBe("60000");
+    });
+  });
+
+  describe("AC-2: Restaurar filtros ao retornar", () => {
+    it("deve restaurar filtros salvos ao montar o componente", () => {
+      const savedFilters = {
+        categoryFilter: "swords",
+        cityFilter: "Caerleon",
+        minPrice: "50000",
+      };
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(savedFilters));
+
+      render(<PriceTable items={mockItems} />);
+
+      // Verifica se o filtro de categoria foi restaurado
+      expect(
+        screen.getByRole("combobox", { name: /category/i }),
+      ).toHaveTextContent(/swords/i);
+    });
+
+    it("deve aplicar filtros restaurados à tabela", () => {
+      const savedFilters = {
+        minPrice: "60000",
+      };
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(savedFilters));
+
+      render(<PriceTable items={mockItems} />);
+
+      // Deve mostrar apenas itens com preço >= 60000
+      expect(screen.getByText("Battleaxe T5")).toBeInTheDocument();
+      expect(screen.queryByText("Broadsword T4")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("AC-3: Limpar filtros remove persistência", () => {
+    it("deve remover filtros do localStorage ao clicar Clear All", async () => {
+      const user = userEvent.setup();
+
+      // Pre-popula localStorage
+      localStorage.setItem(
+        LOCAL_STORAGE_KEY,
+        JSON.stringify({
+          categoryFilter: "swords",
+          minPrice: "50000",
+        }),
+      );
+
+      render(<PriceTable items={mockItems} />);
+
+      const clearButton = screen.getByRole("button", { name: /clear all/i });
+      await user.click(clearButton);
+
+      const saved = localStorage.getItem(LOCAL_STORAGE_KEY);
+      expect(saved).toBeNull();
+    });
+
+    it("deve resetar filtros para o padrão após Clear All", async () => {
+      const user = userEvent.setup();
+
+      localStorage.setItem(
+        LOCAL_STORAGE_KEY,
+        JSON.stringify({
+          categoryFilter: "swords",
+          cityFilter: "Caerleon",
+        }),
+      );
+
+      render(<PriceTable items={mockItems} />);
+
+      const clearButton = screen.getByRole("button", { name: /clear all/i });
+      await user.click(clearButton);
+
+      // Filtros devem voltar para "All"
+      expect(
+        screen.getByRole("combobox", { name: /category/i }),
+      ).toHaveTextContent(/all/i);
+      expect(screen.getByRole("combobox", { name: /city/i })).toHaveTextContent(
+        /all/i,
+      );
+    });
+  });
+
+  describe("AC-4: Validação defensiva de dados persistidos", () => {
+    it("deve ignorar dados inválidos no localStorage", () => {
+      localStorage.setItem(LOCAL_STORAGE_KEY, "invalid-json{{");
+
+      // Não deve lançar erro
+      expect(() => render(<PriceTable items={mockItems} />)).not.toThrow();
+    });
+
+    it("deve remover dados inválidos do localStorage", () => {
+      localStorage.setItem(LOCAL_STORAGE_KEY, "invalid-json{{");
+
+      render(<PriceTable items={mockItems} />);
+
+      // Deve limpar o localStorage corrompido
+      expect(localStorage.getItem(LOCAL_STORAGE_KEY)).toBeNull();
+    });
+
+    it("deve ignorar valores com tipos incorretos", () => {
+      const corruptedData = {
+        categoryFilter: 123, // deveria ser string
+        minPrice: true, // deveria ser string
+      };
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(corruptedData));
+
+      render(<PriceTable items={mockItems} />);
+
+      // Deve usar valores padrão, não os corrompidos
+      expect(
+        screen.getByRole("combobox", { name: /category/i }),
+      ).toHaveTextContent(/all/i);
+    });
+  });
+});

--- a/src/test/PriceTable.test.tsx
+++ b/src/test/PriceTable.test.tsx
@@ -1,329 +1,342 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { PriceTable } from '@/components/dashboard/PriceTable';
-import type { MarketItem } from '@/data/types';
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PriceTable } from "@/components/dashboard/PriceTable";
+import type { MarketItem } from "@/data/types";
+
+beforeEach(() => {
+  localStorage.clear();
+});
 
 const mockItems: MarketItem[] = [
   {
-    itemId: 'T4_MAIN_SWORD',
-    itemName: 'Broadsword T4',
-    city: 'Caerleon',
+    itemId: "T4_MAIN_SWORD",
+    itemName: "Broadsword T4",
+    city: "Caerleon",
     sellPrice: 50000,
     buyPrice: 40000,
     spread: 10000,
     spreadPercent: 25,
     timestamp: new Date().toISOString(),
-    tier: 'T4',
-    quality: 'Normal',
+    tier: "T4",
+    quality: "Normal",
     priceHistory: [45000, 46000, 47000],
   },
   {
-    itemId: 'T5_MAIN_AXE',
-    itemName: 'Battleaxe T5',
-    city: 'Bridgewatch',
+    itemId: "T5_MAIN_AXE",
+    itemName: "Battleaxe T5",
+    city: "Bridgewatch",
     sellPrice: 80000,
     buyPrice: 60000,
     spread: 20000,
     spreadPercent: 33,
     timestamp: new Date().toISOString(),
-    tier: 'T5',
-    quality: 'Normal',
+    tier: "T5",
+    quality: "Normal",
     priceHistory: [75000, 77000, 80000],
   },
   {
-    itemId: 'T4_BAG@2',
-    itemName: 'Bag T4.2',
-    city: 'Martlock',
+    itemId: "T4_BAG@2",
+    itemName: "Bag T4.2",
+    city: "Martlock",
     sellPrice: 65000,
     buyPrice: 50000,
     spread: 15000,
     spreadPercent: 30,
     timestamp: new Date().toISOString(),
-    tier: 'T4',
-    quality: 'Outstanding',
+    tier: "T4",
+    quality: "Outstanding",
     priceHistory: [62000, 63000, 65000],
   },
 ];
 
-async function selectOption(triggerText: RegExp | string, optionText: RegExp | string) {
+async function selectOption(
+  triggerText: RegExp | string,
+  optionText: RegExp | string,
+) {
   const user = userEvent.setup();
-  await user.click(screen.getByRole('combobox', { name: triggerText }));
-  await user.click(await screen.findByRole('option', { name: optionText }));
+  await user.click(screen.getByRole("combobox", { name: triggerText }));
+  await user.click(await screen.findByRole("option", { name: optionText }));
 }
 
-describe('PriceTable — filtro de categoria (AC6)', () => {
+describe("PriceTable — filtro de categoria (AC6)", () => {
   it('exibe Select de categoria com opção "All Categories"', () => {
     render(<PriceTable items={mockItems} />);
 
-    expect(screen.getByRole('combobox', { name: /category/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: /category/i }),
+    ).toBeInTheDocument();
   });
 
-  it('exibe labels de categoria legíveis no Select', async () => {
+  it("exibe labels de categoria legíveis no Select", async () => {
     render(<PriceTable items={mockItems} />);
 
-    const categorySelect = screen.getByRole('combobox', { name: /category/i });
+    const categorySelect = screen.getByRole("combobox", { name: /category/i });
     expect(categorySelect).toBeInTheDocument();
   });
 });
 
-describe('PriceTable — filtros de faixa (AC1, AC2)', () => {
-  it('exibe inputs de faixa de preço (min/max)', () => {
+describe("PriceTable — filtros de faixa (AC1, AC2)", () => {
+  it("exibe inputs de faixa de preço (min/max)", () => {
     render(<PriceTable items={mockItems} />);
 
     expect(screen.getByPlaceholderText(/min price/i)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/max price/i)).toBeInTheDocument();
   });
 
-  it('exibe inputs de faixa de spread (min/max)', () => {
+  it("exibe inputs de faixa de spread (min/max)", () => {
     render(<PriceTable items={mockItems} />);
 
     expect(screen.getByPlaceholderText(/min spread/i)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/max spread/i)).toBeInTheDocument();
   });
 
-  it('filtra itens por faixa de preço', async () => {
+  it("filtra itens por faixa de preço", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
     const minPriceInput = screen.getByPlaceholderText(/min price/i);
-    await user.type(minPriceInput, '60000');
+    await user.type(minPriceInput, "60000");
 
     // Deve mostrar apenas T5_MAIN_AXE (80000/60000)
-    expect(screen.getByText('Battleaxe T5')).toBeInTheDocument();
-    expect(screen.queryByText('Broadsword T4')).not.toBeInTheDocument();
+    expect(screen.getByText("Battleaxe T5")).toBeInTheDocument();
+    expect(screen.queryByText("Broadsword T4")).not.toBeInTheDocument();
   });
 
-  it('filtra itens por faixa de spread percentual', async () => {
+  it("filtra itens por faixa de spread percentual", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
     const minSpreadInput = screen.getByPlaceholderText(/min spread/i);
-    await user.type(minSpreadInput, '30');
+    await user.type(minSpreadInput, "30");
 
     // Deve mostrar apenas T5_MAIN_AXE (33%)
-    expect(screen.getByText('Battleaxe T5')).toBeInTheDocument();
-    expect(screen.queryByText('Broadsword T4')).not.toBeInTheDocument();
+    expect(screen.getByText("Battleaxe T5")).toBeInTheDocument();
+    expect(screen.queryByText("Broadsword T4")).not.toBeInTheDocument();
   });
 });
 
-describe('PriceTable — Clear All e indicador (AC3, AC4)', () => {
-  it('exibe botão Clear All quando filtros estão ativos', async () => {
+describe("PriceTable — Clear All e indicador (AC3, AC4)", () => {
+  it("exibe botão Clear All quando filtros estão ativos", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
     const minPriceInput = screen.getByPlaceholderText(/min price/i);
-    await user.type(minPriceInput, '1000');
+    await user.type(minPriceInput, "1000");
 
-    expect(screen.getByRole('button', { name: /clear all/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear all/i }),
+    ).toBeInTheDocument();
   });
 
-  it('exibe contador de filtros ativos', async () => {
+  it("exibe contador de filtros ativos", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
     const minPriceInput = screen.getByPlaceholderText(/min price/i);
-    await user.type(minPriceInput, '1000');
+    await user.type(minPriceInput, "1000");
 
     expect(screen.getByText(/1 filter active/i)).toBeInTheDocument();
   });
 
-  it('limpa todos os filtros ao clicar Clear All', async () => {
+  it("limpa todos os filtros ao clicar Clear All", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
     const minPriceInput = screen.getByPlaceholderText(/min price/i);
-    await user.type(minPriceInput, '60000');
+    await user.type(minPriceInput, "60000");
 
-    const clearButton = screen.getByRole('button', { name: /clear all/i });
+    const clearButton = screen.getByRole("button", { name: /clear all/i });
     await user.click(clearButton);
 
     // Todos os itens devem aparecer novamente
-    expect(screen.getByText('Broadsword T4')).toBeInTheDocument();
-    expect(screen.getByText('Battleaxe T5')).toBeInTheDocument();
+    expect(screen.getByText("Broadsword T4")).toBeInTheDocument();
+    expect(screen.getByText("Battleaxe T5")).toBeInTheDocument();
   });
 });
 
-describe('PriceTable — ordenação', () => {
-  it('ordena itens ao clicar no cabeçalho', async () => {
+describe("PriceTable — ordenação", () => {
+  it("ordena itens ao clicar no cabeçalho", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
-    const sellPriceHeader = screen.getByRole('button', { name: /sell price/i });
+    const sellPriceHeader = screen.getByRole("button", { name: /sell price/i });
     await user.click(sellPriceHeader);
 
     expect(sellPriceHeader).toBeInTheDocument();
   });
 
-  it('alterna direção da ordenação ao clicar novamente no mesmo cabeçalho', async () => {
+  it("alterna direção da ordenação ao clicar novamente no mesmo cabeçalho", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
-    const spreadHeader = screen.getByRole('button', { name: /spread/i });
+    const spreadHeader = screen.getByRole("button", { name: /spread/i });
     await user.click(spreadHeader);
     await user.click(spreadHeader);
 
     expect(spreadHeader).toBeInTheDocument();
   });
 
-  it('ordena por nome do item', async () => {
+  it("ordena por nome do item", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
-    const itemNameHeader = screen.getByRole('button', { name: /item/i });
+    const itemNameHeader = screen.getByRole("button", { name: /item/i });
     await user.click(itemNameHeader);
 
     expect(itemNameHeader).toBeInTheDocument();
-    expect(screen.getByText('Broadsword T4')).toBeInTheDocument();
-    expect(screen.getByText('Battleaxe T5')).toBeInTheDocument();
+    expect(screen.getByText("Broadsword T4")).toBeInTheDocument();
+    expect(screen.getByText("Battleaxe T5")).toBeInTheDocument();
   });
 });
 
-describe('PriceTable — estado vazio', () => {
-  it('exibe mensagem quando nenhum item corresponde aos critérios', () => {
+describe("PriceTable — estado vazio", () => {
+  it("exibe mensagem quando nenhum item corresponde aos critérios", () => {
     render(<PriceTable items={[]} />);
 
     expect(screen.getByText(/no items found/i)).toBeInTheDocument();
   });
 
-  it('exibe estado vazio quando filtros não retornam resultados', async () => {
+  it("exibe estado vazio quando filtros não retornam resultados", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
     const minPriceInput = screen.getByPlaceholderText(/min price/i);
-    await user.type(minPriceInput, '999999');
+    await user.type(minPriceInput, "999999");
 
     expect(screen.getByText(/no items found/i)).toBeInTheDocument();
   });
 });
 
-describe('PriceTable — filtros adicionais', () => {
-  it('filtra por max price', async () => {
+describe("PriceTable — filtros adicionais", () => {
+  it("filtra por max price", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
     const maxPriceInput = screen.getByPlaceholderText(/max price/i);
-    await user.type(maxPriceInput, '60000');
+    await user.type(maxPriceInput, "60000");
 
-    expect(screen.getByText('Broadsword T4')).toBeInTheDocument();
-    expect(screen.queryByText('Battleaxe T5')).not.toBeInTheDocument();
+    expect(screen.getByText("Broadsword T4")).toBeInTheDocument();
+    expect(screen.queryByText("Battleaxe T5")).not.toBeInTheDocument();
   });
 
-  it('filtra por max spread', async () => {
+  it("filtra por max spread", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
     const maxSpreadInput = screen.getByPlaceholderText(/max spread %/i);
-    await user.type(maxSpreadInput, '30');
+    await user.type(maxSpreadInput, "30");
 
-    expect(screen.getByText('Broadsword T4')).toBeInTheDocument();
-    expect(screen.queryByText('Battleaxe T5')).not.toBeInTheDocument();
+    expect(screen.getByText("Broadsword T4")).toBeInTheDocument();
+    expect(screen.queryByText("Battleaxe T5")).not.toBeInTheDocument();
   });
 
-  it('filtra por categoria usando o select', async () => {
+  it("filtra por categoria usando o select", async () => {
     render(<PriceTable items={mockItems} />);
 
     await selectOption(/category/i, /bags/i);
 
-    expect(screen.getByText('Bag T4.2')).toBeInTheDocument();
-    expect(screen.queryByText('Broadsword T4')).not.toBeInTheDocument();
-    expect(screen.queryByText('Battleaxe T5')).not.toBeInTheDocument();
+    expect(screen.getByText("Bag T4.2")).toBeInTheDocument();
+    expect(screen.queryByText("Broadsword T4")).not.toBeInTheDocument();
+    expect(screen.queryByText("Battleaxe T5")).not.toBeInTheDocument();
   });
 
-  it('filtra por encantamento usando o select', async () => {
+  it("filtra por encantamento usando o select", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
-    const comboboxes = screen.getAllByRole('combobox');
+    const comboboxes = screen.getAllByRole("combobox");
     await user.click(comboboxes[4]);
-    await user.click(await screen.findByRole('option', { name: /level 2/i }));
+    await user.click(await screen.findByRole("option", { name: /level 2/i }));
 
-    expect(screen.getByText('Bag T4.2')).toBeInTheDocument();
-    expect(screen.queryByText('Broadsword T4')).not.toBeInTheDocument();
-    expect(screen.queryByText('Battleaxe T5')).not.toBeInTheDocument();
+    expect(screen.getByText("Bag T4.2")).toBeInTheDocument();
+    expect(screen.queryByText("Broadsword T4")).not.toBeInTheDocument();
+    expect(screen.queryByText("Battleaxe T5")).not.toBeInTheDocument();
   });
 
-  it('filtra por cidade usando o select', async () => {
+  it("filtra por cidade usando o select", async () => {
     render(<PriceTable items={mockItems} />);
 
     const user = userEvent.setup();
-    const comboboxes = screen.getAllByRole('combobox');
+    const comboboxes = screen.getAllByRole("combobox");
     await user.click(comboboxes[1]);
-    await user.click(await screen.findByRole('option', { name: 'Martlock' }));
+    await user.click(await screen.findByRole("option", { name: "Martlock" }));
 
-    expect(screen.getByText('Bag T4.2')).toBeInTheDocument();
-    expect(screen.queryByText('Broadsword T4')).not.toBeInTheDocument();
-    expect(screen.queryByText('Battleaxe T5')).not.toBeInTheDocument();
+    expect(screen.getByText("Bag T4.2")).toBeInTheDocument();
+    expect(screen.queryByText("Broadsword T4")).not.toBeInTheDocument();
+    expect(screen.queryByText("Battleaxe T5")).not.toBeInTheDocument();
   });
 });
 
-describe('PriceTable — busca', () => {
-  it('filtra itens por nome', async () => {
+describe("PriceTable — busca", () => {
+  it("filtra itens por nome", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
     const searchInput = screen.getByPlaceholderText(/search by item name/i);
-    await user.type(searchInput, 'Sword');
+    await user.type(searchInput, "Sword");
 
-    expect(screen.getByText('Broadsword T4')).toBeInTheDocument();
-    expect(screen.queryByText('Battleaxe T5')).not.toBeInTheDocument();
+    expect(screen.getByText("Broadsword T4")).toBeInTheDocument();
+    expect(screen.queryByText("Battleaxe T5")).not.toBeInTheDocument();
   });
 
-  it('filtra itens por ID', async () => {
+  it("filtra itens por ID", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
     const searchInput = screen.getByPlaceholderText(/search by item name/i);
-    await user.type(searchInput, 'T5_MAIN_AXE');
+    await user.type(searchInput, "T5_MAIN_AXE");
 
-    expect(screen.queryByText('Broadsword T4')).not.toBeInTheDocument();
-    expect(screen.getByText('Battleaxe T5')).toBeInTheDocument();
+    expect(screen.queryByText("Broadsword T4")).not.toBeInTheDocument();
+    expect(screen.getByText("Battleaxe T5")).toBeInTheDocument();
   });
 });
 
-describe('PriceTable — paginação', () => {
+describe("PriceTable — paginação", () => {
   const manyItems: MarketItem[] = Array.from({ length: 25 }, (_, i) => ({
     itemId: `T4_ITEM_${i}`,
     itemName: `Item ${i}`,
-    city: 'Caerleon',
+    city: "Caerleon",
     sellPrice: 50000 + i * 1000,
     buyPrice: 40000 + i * 1000,
     spread: 10000,
     spreadPercent: 25,
     timestamp: new Date().toISOString(),
-    tier: 'T4',
-    quality: 'Normal',
+    tier: "T4",
+    quality: "Normal",
     priceHistory: [45000, 46000, 47000],
   }));
 
-  it('exibe controles de paginação quando há muitos itens', () => {
+  it("exibe controles de paginação quando há muitos itens", () => {
     render(<PriceTable items={manyItems} />);
 
-    expect(screen.getByText(/showing 1 to 10 of 25 items/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/showing 1 to 10 of 25 items/i),
+    ).toBeInTheDocument();
   });
 
-  it('exibe números de página quando há muitos itens', () => {
+  it("exibe números de página quando há muitos itens", () => {
     render(<PriceTable items={manyItems} />);
 
-    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '2' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '3' })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "1" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "2" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "3" })).toBeInTheDocument();
   });
 });
 
-describe('PriceTable — filtros combinados', () => {
-  it('aplica múltiplos filtros simultaneamente', async () => {
+describe("PriceTable — filtros combinados", () => {
+  it("aplica múltiplos filtros simultaneamente", async () => {
     const user = userEvent.setup();
     render(<PriceTable items={mockItems} />);
 
     const minPriceInput = screen.getByPlaceholderText(/min price/i);
     const maxPriceInput = screen.getByPlaceholderText(/max price/i);
 
-    await user.type(minPriceInput, '40000');
-    await user.type(maxPriceInput, '60000');
+    await user.type(minPriceInput, "40000");
+    await user.type(maxPriceInput, "60000");
 
-    expect(screen.getByText('Broadsword T4')).toBeInTheDocument();
-    expect(screen.queryByText('Battleaxe T5')).not.toBeInTheDocument();
+    expect(screen.getByText("Broadsword T4")).toBeInTheDocument();
+    expect(screen.queryByText("Battleaxe T5")).not.toBeInTheDocument();
 
     expect(screen.getByText(/2 filter active/i)).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
Implementa AC-5 do SPEC enhanced-ui-filters: filtros do PriceTable agora persistem em localStorage.

## Changes
- Novo serviço `filter.storage.ts` com validação defensiva
- Integração no PriceTable: salva ao alterar, restaura ao montar
- Clear All remove persistência completamente
- Testes: 10 novos cobrindo todos os ACs

## Validation
- 215/215 testes passando
- Lint OK
- Build OK
- Security Review: PASS (validação defensiva, React escapa output)

## Testing
```bash
npm run test -- src/test/PriceTable.persistence.test.tsx
```

Closes gap do PR #25 (enhanced-ui-filters).