### PR TITLE
feat(lote-1a): item 1 - corrigir contrato de alerta 'change'

### DIFF
--- a/src/hooks/useAlertPoller.ts
+++ b/src/hooks/useAlertPoller.ts
@@ -19,24 +19,32 @@ export function useAlertPoller() {
     const fired = checkAlerts(items, alerts);
     const now = Date.now();
 
-    for (const { alert, item, currentPrice } of fired) {
-      // Respeitar preferência de notificação inApp do usuário
-      if (!alert.notifications?.inApp) continue;
-
+    for (const { alert, item, currentPrice, priceChangePercent } of fired) {
       const lastTime = lastFiredAt.current[alert.id] ?? 0;
       if (now - lastTime < NOTIFICATION_COOLDOWN_MS) continue;
 
       lastFiredAt.current[alert.id] = now;
 
-      const conditionText =
-        alert.condition === 'below'
-          ? `abaixo de ${alert.threshold.toLocaleString()}`
-          : alert.condition === 'above'
-            ? `acima de ${alert.threshold.toLocaleString()}`
-            : `variação ≥ ${alert.threshold}%`;
+      let conditionText: string;
+      let description: string;
 
-      toast.warning(`⚠️ ${item.itemName} — preço ${conditionText}`, {
-        description: `Preço atual: ${currentPrice.toLocaleString()} em ${item.city}`,
+      if (alert.condition === 'below') {
+        conditionText = `abaixo de ${alert.threshold.toLocaleString()}`;
+        description = `Preço atual: ${currentPrice.toLocaleString()} em ${item.city}`;
+      } else if (alert.condition === 'above') {
+        conditionText = `acima de ${alert.threshold.toLocaleString()}`;
+        description = `Preço atual: ${currentPrice.toLocaleString()} em ${item.city}`;
+      } else {
+        // Condição 'change' - variação percentual temporal
+        const changeText = priceChangePercent !== undefined 
+          ? `${priceChangePercent >= 0 ? '+' : ''}${priceChangePercent.toFixed(1)}%`
+          : 'N/A';
+        conditionText = `variação de ${changeText}`;
+        description = `Variação detectada: ${changeText} (limite: ${alert.threshold}%)`;
+      }
+
+      toast.warning(`⚠️ ${item.itemName} — ${conditionText}`, {
+        description,
         duration: 8000,
       });
     }

--- a/src/services/alert.engine.ts
+++ b/src/services/alert.engine.ts
@@ -4,6 +4,26 @@ export interface FiredAlert {
   alert: Alert;
   item: MarketItem;
   currentPrice: number;
+  priceChangePercent?: number;
+}
+
+/**
+ * Calcula a variação percentual de preço ao longo do tempo.
+ * Usa o histórico de preços para determinar a variação.
+ * @returns Variação percentual (ex: 5.5 para +5.5%, -3.2 para -3.2%)
+ */
+function calculatePriceChangePercent(item: MarketItem): number {
+  if (!item.priceHistory || item.priceHistory.length < 2) {
+    return 0;
+  }
+
+  const currentPrice = item.sellPrice;
+  // Usa o preço mais antigo do histórico como baseline
+  const baselinePrice = item.priceHistory[0];
+  
+  if (baselinePrice === 0) return 0;
+  
+  return ((currentPrice - baselinePrice) / baselinePrice) * 100;
 }
 
 export function checkAlerts(items: MarketItem[], alerts: Alert[]): FiredAlert[] {
@@ -11,6 +31,7 @@ export function checkAlerts(items: MarketItem[], alerts: Alert[]): FiredAlert[] 
 
   for (const alert of alerts) {
     if (!alert.isActive) continue;
+    if (!alert.notifications?.inApp) continue;
 
     const item = items.find(
       i =>
@@ -20,13 +41,27 @@ export function checkAlerts(items: MarketItem[], alerts: Alert[]): FiredAlert[] 
     if (!item) continue;
 
     const price = item.sellPrice;
-    const triggered =
-      (alert.condition === 'below' && price < alert.threshold) ||
-      (alert.condition === 'above' && price > alert.threshold) ||
-      (alert.condition === 'change' && item.spreadPercent >= alert.threshold);
+    let triggered = false;
+    let priceChangePercent: number | undefined;
+
+    if (alert.condition === 'below') {
+      triggered = price < alert.threshold;
+    } else if (alert.condition === 'above') {
+      triggered = price > alert.threshold;
+    } else if (alert.condition === 'change') {
+      // Variação percentual temporal (não spreadPercent)
+      priceChangePercent = calculatePriceChangePercent(item);
+      // Dispara quando a variação absoluta é maior ou igual ao threshold
+      triggered = Math.abs(priceChangePercent) >= alert.threshold;
+    }
 
     if (triggered) {
-      fired.push({ alert, item, currentPrice: price });
+      fired.push({ 
+        alert, 
+        item, 
+        currentPrice: price,
+        priceChangePercent,
+      });
     }
   }
 

--- a/src/test/alert.engine.test.ts
+++ b/src/test/alert.engine.test.ts
@@ -84,9 +84,12 @@ describe('checkAlerts()', () => {
     expect(fired).toHaveLength(0);
   });
 
-  it('dispara alerta condition=change quando spreadPercent >= threshold', () => {
-    // Given
-    const items = [makeItem({ spreadPercent: 25 })];
+  it('dispara alerta condition=change quando variação temporal >= threshold', () => {
+    // Given - preço subiu de 40000 para 50000 (25% de variação)
+    const items = [makeItem({ 
+      sellPrice: 50000,
+      priceHistory: [40000, 45000, 48000] // baseline: 40000
+    })];
     const alerts = [makeAlert({ condition: 'change', threshold: 20 })];
 
     // When
@@ -94,11 +97,15 @@ describe('checkAlerts()', () => {
 
     // Then
     expect(fired).toHaveLength(1);
+    expect(fired[0].priceChangePercent).toBe(25);
   });
 
-  it('não dispara condition=change quando spreadPercent < threshold', () => {
-    // Given
-    const items = [makeItem({ spreadPercent: 15 })];
+  it('não dispara condition=change quando variação temporal < threshold', () => {
+    // Given - preço subiu de 48000 para 50000 (4.17% de variação)
+    const items = [makeItem({ 
+      sellPrice: 50000,
+      priceHistory: [48000, 49000] // baseline: 48000
+    })];
     const alerts = [makeAlert({ condition: 'change', threshold: 20 })];
 
     // When
@@ -108,10 +115,42 @@ describe('checkAlerts()', () => {
     expect(fired).toHaveLength(0);
   });
 
+  it('dispara alerta condition=change quando variação negativa >= threshold', () => {
+    // Given - preço caiu de 60000 para 40000 (-33.33% de variação)
+    const items = [makeItem({ 
+      sellPrice: 40000,
+      priceHistory: [60000, 55000, 50000] // baseline: 60000
+    })];
+    const alerts = [makeAlert({ condition: 'change', threshold: 30 })];
+
+    // When
+    const fired = checkAlerts(items, alerts);
+
+    // Then
+    expect(fired).toHaveLength(1);
+    expect(fired[0].priceChangePercent).toBeCloseTo(-33.33, 1);
+  });
+
   it('não dispara quando alerta está inativo (isActive: false)', () => {
     // Given
     const items = [makeItem({ sellPrice: 30000 })];
     const alerts = [makeAlert({ isActive: false, condition: 'below', threshold: 60000 })];
+
+    // When
+    const fired = checkAlerts(items, alerts);
+
+    // Then
+    expect(fired).toHaveLength(0);
+  });
+
+  it('não dispara quando notificação inApp está desabilitada', () => {
+    // Given
+    const items = [makeItem({ sellPrice: 30000 })];
+    const alerts = [makeAlert({ 
+      condition: 'below', 
+      threshold: 60000,
+      notifications: { inApp: false, email: false }
+    })];
 
     // When
     const fired = checkAlerts(items, alerts);


### PR DESCRIPTION
- Criar calculatePriceChangePercent() para variação temporal real
- Substituir spreadPercent por variação temporal na condição 'change'
- Alerta 'change' agora dispara com base no histórico de preços
- Adicionar priceChangePercent no retorno de FiredAlert
- Atualizar useAlertPoller para mostrar variação real no toast
- Atualizar testes para refletir nova lógica de variação temporal
- Adicionar teste para verificar que não dispara quando inApp=false

A UI prometia 'price change' mas engine usava spreadPercent. Agora usa variação percentual temporal real baseada no histórico.

Item 1 do Lote 1A concluído. ✅