### PR TITLE
fix(tests): restore quality gate mocks

### DIFF
--- a/src/test/market.api.batch.test.ts
+++ b/src/test/market.api.batch.test.ts
@@ -2,11 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const MOCK_IDS = Array.from({ length: 200 }, (_, i) => `T4_ITEM_${i}`);
 
-vi.mock('@/data/constants', () => ({
-  ITEM_IDS: MOCK_IDS,
-  ITEM_NAMES: {},
-  ITEM_CATALOG: { mock: { label: 'Mock', ids: MOCK_IDS } },
-}));
+vi.mock('@/data/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/data/constants')>();
+
+  return {
+    ...actual,
+    ITEM_IDS: MOCK_IDS,
+    ITEM_NAMES: actual.ITEM_NAMES,
+  };
+});
 
 vi.mock('@/services/alert.storage', () => {
   function MockAlertStorageService() {

--- a/src/test/market.api.retry.test.ts
+++ b/src/test/market.api.retry.test.ts
@@ -4,14 +4,18 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 // Todos os testes neste arquivo são RED — fetchWithRetry não existe ainda
 
 // Mock global necessário para AC-4 e AC-5 (evita erros de exports em mockData.ts)
-vi.mock('@/data/constants', () => ({
-  ITEM_IDS: ['T4_MAIN_SWORD'],
-  ITEM_NAMES: { T4_MAIN_SWORD: 'Broadsword T4' },
-  ITEM_CATALOG: { weapons: { label: 'Weapons', ids: ['T4_MAIN_SWORD'] } },
-  cities: ['Caerleon'],
-  tiers: ['T4'],
-  qualities: ['Normal'],
-}));
+vi.mock('@/data/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/data/constants')>();
+
+  return {
+    ...actual,
+    ITEM_IDS: ['T4_MAIN_SWORD'],
+    ITEM_NAMES: {
+      ...actual.ITEM_NAMES,
+      T4_MAIN_SWORD: 'Broadsword T4',
+    },
+  };
+});
 
 vi.mock('@/services/alert.storage', () => {
   function AlertStorageService() {

--- a/src/test/market.cache.test.ts
+++ b/src/test/market.cache.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { CACHE_KEY, CACHE_TTL_MS, readCache, writeCache, isCacheValid } from '@/services/market.cache';
 import { ApiMarketService } from '@/services/market.api';
+import { DATA_FRESHNESS_MS } from '@/data/constants';
 import type { MarketItem } from '@/data/types';
 
 vi.mock('@/services/alert.storage', () => ({
@@ -36,8 +37,9 @@ describe('market.cache — AC-1: writeCache persiste no localStorage', () => {
     expect(CACHE_KEY.length).toBeGreaterThan(0);
   });
 
-  it('CACHE_TTL_MS é exportado com valor 300000 (5 min)', () => {
-    expect(CACHE_TTL_MS).toBe(300_000);
+  it('CACHE_TTL_MS segue a política única de frescor (15 min)', () => {
+    expect(CACHE_TTL_MS).toBe(DATA_FRESHNESS_MS);
+    expect(CACHE_TTL_MS).toBe(900_000);
   });
 
   it('writeCache persiste os dados no localStorage', () => {


### PR DESCRIPTION
## Contexto
Corrige falhas no Quality Gate causadas por mocks desatualizados de @/data/constants e por uma expectativa antiga de TTL em testes de cache.

## Ajustes
- usa mock parcial com importOriginal em market.api.retry.test.ts
- usa mock parcial com importOriginal em market.api.batch.test.ts
- alinha market.cache.test.ts com a politica atual de frescor de 15 minutos

## Validacao
- npm run quality:gate
