### PR TITLE
fix(ci): upgrade actions for node 24

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## Contexto
Atualiza o workflow Quality Gate para usar majors dos actions compativeis com o runtime Node 24 dos runners do GitHub.

## Ajuste
- actions/checkout: v4 -> v5
- actions/setup-node: v4 -> v5
- mantem node-version 20 e npm 10.8.2 do projeto sem alterar o runtime efetivo da aplicacao

## Fonte oficial
- setup-node v5 release indica upgrade do action para node24
- checkout v5 usado no mesmo exemplo oficial da release

## Risco
- baixo; mudanca restrita ao runtime dos actions
