### PR TITLE
test: stabilize flaky suite and strict typecheck checks (#59)

### DIFF
--- a/PENDING_LOG.md
+++ b/PENDING_LOG.md
@@ -138,6 +138,7 @@
 - [ ] **`quality:gate` com `typecheck` explícito** (`tsc --noEmit`) + cobertura de configs TS de toolchain.
 - [ ] **Smoke E2E obrigatório no CI** (PR), mantendo suíte completa em job dedicado quando necessário.
 - [ ] **Threshold oficial de coverage** com enforcement gradual no CI.
+- [x] **Frente #59 — estabilização de flakies em testes** (2026-03-20): timeout global de teste ampliado para 20s + hookTimeout 30s em `vite.config.ts`; `tsconfig.strict.test.ts` migrou de `npx tsc` para binário local do TypeScript com timeout explícito de 60s por caso; `PriceTable.persistence.test.tsx` estabilizado no fluxo de seleção de categoria (`listbox` + `within`) para evitar timeout intermitente no Radix Select; `npm test` e `quality:gate` verdes (`323/323` testes).
 - [ ] **Atualizar docs com drift**: `CONTEXT.md`, ADR-003, ADR-005, README e notas de workflow.
 - [ ] **Política de privacidade/retenção localStorage**: documentar escopo, retenção e limpeza.
 - [ ] **Política de artefatos `dist/`**: manter não versionado; gerar apenas em build/CI.

--- a/src/test/PriceTable.persistence.test.tsx
+++ b/src/test/PriceTable.persistence.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PriceTable } from "@/components/dashboard/PriceTable";
 import type { MarketItem } from "@/data/types";
@@ -66,7 +66,10 @@ describe("PriceTable — persistência de filtros (AC-5)", () => {
         name: /category/i,
       });
       await user.click(categorySelect);
-      await user.click(await screen.findByRole("option", { name: /swords/i }));
+
+      const listbox = await screen.findByRole("listbox");
+      const swordsOption = within(listbox).getByText(/swords/i);
+      await user.click(swordsOption);
 
       const saved = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || "{}");
       expect(saved.categoryFilter).toBe("swords");

--- a/src/test/tsconfig.strict.test.ts
+++ b/src/test/tsconfig.strict.test.ts
@@ -32,22 +32,37 @@ describe("tsconfig.json — strict mode iteração 5 (consolidação)", () => {
   });
 });
 
+function runTscNoEmit(): string {
+  try {
+    execSync("node ./node_modules/typescript/bin/tsc --noEmit", {
+      cwd: resolve(process.cwd()),
+      stdio: "pipe",
+      timeout: 60_000,
+    });
+    return "";
+  } catch (err: unknown) {
+    const stdout =
+      (err as { stdout?: Buffer; stderr?: Buffer }).stdout?.toString() ?? "";
+    const stderr =
+      (err as { stdout?: Buffer; stderr?: Buffer }).stderr?.toString() ?? "";
+    return `${stdout}\n${stderr}`;
+  }
+}
+
 describe("src/pages/ — strict mode iteração 3 (AC-1): compilação limpa", () => {
-  it("tsc --noEmit não deve reportar erros em src/pages/", () => {
-    let output = "";
-    try {
-      execSync("npx tsc --noEmit 2>&1", { cwd: resolve(process.cwd()) });
-    } catch (err: unknown) {
-      output =
-        (err as { stdout?: Buffer; stderr?: Buffer }).stdout?.toString() ?? "";
-    }
-    const pageErrors = output
-      .split("\n")
-      .filter(
-        (line) => line.includes("src/pages/") && line.includes("error TS"),
-      );
-    expect(pageErrors).toHaveLength(0);
-  });
+  it(
+    "tsc --noEmit não deve reportar erros em src/pages/",
+    () => {
+      const output = runTscNoEmit();
+      const pageErrors = output
+        .split("\n")
+        .filter(
+          (line) => line.includes("src/pages/") && line.includes("error TS"),
+        );
+      expect(pageErrors).toHaveLength(0);
+    },
+    60_000,
+  );
 });
 
 describe("src/pages/ — strict mode iteração 3 (AC-2): sem supressões de tipo", () => {
@@ -65,24 +80,22 @@ describe("src/pages/ — strict mode iteração 3 (AC-2): sem supressões de tip
 });
 
 describe("src/components/ — strict mode iteração 4 (AC-1): compilação limpa", () => {
-  it("tsc --noEmit não deve reportar erros em src/components/ (exceto ui/)", () => {
-    let output = "";
-    try {
-      execSync("npx tsc --noEmit 2>&1", { cwd: resolve(process.cwd()) });
-    } catch (err: unknown) {
-      output =
-        (err as { stdout?: Buffer; stderr?: Buffer }).stdout?.toString() ?? "";
-    }
-    const componentErrors = output
-      .split("\n")
-      .filter(
-        (line) =>
-          line.includes("src/components/") &&
-          !line.includes("src/components/ui/") &&
-          line.includes("error TS"),
-      );
-    expect(componentErrors).toHaveLength(0);
-  });
+  it(
+    "tsc --noEmit não deve reportar erros em src/components/ (exceto ui/)",
+    () => {
+      const output = runTscNoEmit();
+      const componentErrors = output
+        .split("\n")
+        .filter(
+          (line) =>
+            line.includes("src/components/") &&
+            !line.includes("src/components/ui/") &&
+            line.includes("error TS"),
+        );
+      expect(componentErrors).toHaveLength(0);
+    },
+    60_000,
+  );
 });
 
 function getComponentFiles(dir: string, files: string[] = []): string[] {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,8 @@ export default defineConfig(({ mode }) => ({
     environment: "jsdom",
     setupFiles: "./src/test/setup.ts",
     css: false,
+    testTimeout: 20000,
+    hookTimeout: 30000,
     include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
     exclude: ["e2e/**", "node_modules/**"],
   },


### PR DESCRIPTION
## Objetivo
Estabilizar a suíte de testes antes de avançar para as próximas frentes de CI/gate.

## Mudanças
- Ajuste de timeouts globais no Vitest (testTimeout: 20000, hookTimeout: 30000)
- tsconfig.strict.test.ts com execução de TypeScript via binário local + timeout explícito de 60s
- Estabilização do fluxo de seleção em PriceTable.persistence.test.tsx usando listbox + within
- Atualização de PENDING_LOG.md com fechamento da frente #59

## Validação
- npm test -> 323/323
- npm run quality:gate -> passando
